### PR TITLE
Switch to internal clock source for examples

### DIFF
--- a/examples/src/bin/ble_advertise.rs
+++ b/examples/src/bin/ble_advertise.rs
@@ -56,9 +56,9 @@ fn main() -> ! {
 
     let config = nrf_softdevice::Config {
         clock: Some(raw::nrf_clock_lf_cfg_t {
-            source: raw::NRF_CLOCK_LF_SRC_XTAL as u8,
-            rc_ctiv: 0,
-            rc_temp_ctiv: 0,
+            source: raw::NRF_CLOCK_LF_SRC_RC as u8,
+            rc_ctiv: 4,
+            rc_temp_ctiv: 2,
             accuracy: 7,
         }),
         conn_gap: Some(raw::ble_gap_conn_cfg_t {

--- a/examples/src/bin/ble_bas_central.rs
+++ b/examples/src/bin/ble_bas_central.rs
@@ -65,9 +65,9 @@ fn main() -> ! {
 
     let config = nrf_softdevice::Config {
         clock: Some(raw::nrf_clock_lf_cfg_t {
-            source: raw::NRF_CLOCK_LF_SRC_XTAL as u8,
-            rc_ctiv: 0,
-            rc_temp_ctiv: 0,
+            source: raw::NRF_CLOCK_LF_SRC_RC as u8,
+            rc_ctiv: 4,
+            rc_temp_ctiv: 2,
             accuracy: 7,
         }),
         conn_gap: Some(raw::ble_gap_conn_cfg_t {

--- a/examples/src/bin/ble_bas_peripheral.rs
+++ b/examples/src/bin/ble_bas_peripheral.rs
@@ -95,9 +95,9 @@ fn main() -> ! {
 
     let config = nrf_softdevice::Config {
         clock: Some(raw::nrf_clock_lf_cfg_t {
-            source: raw::NRF_CLOCK_LF_SRC_XTAL as u8,
-            rc_ctiv: 0,
-            rc_temp_ctiv: 0,
+            source: raw::NRF_CLOCK_LF_SRC_RC as u8,
+            rc_ctiv: 4,
+            rc_temp_ctiv: 2,
             accuracy: 7,
         }),
         conn_gap: Some(raw::ble_gap_conn_cfg_t {

--- a/examples/src/bin/ble_l2cap_central.rs
+++ b/examples/src/bin/ble_l2cap_central.rs
@@ -130,9 +130,9 @@ fn main() -> ! {
 
     let config = nrf_softdevice::Config {
         clock: Some(raw::nrf_clock_lf_cfg_t {
-            source: raw::NRF_CLOCK_LF_SRC_XTAL as u8,
-            rc_ctiv: 0,
-            rc_temp_ctiv: 0,
+            source: raw::NRF_CLOCK_LF_SRC_RC as u8,
+            rc_ctiv: 4,
+            rc_temp_ctiv: 2,
             accuracy: 7,
         }),
         conn_gap: Some(raw::ble_gap_conn_cfg_t {

--- a/examples/src/bin/ble_l2cap_peripheral.rs
+++ b/examples/src/bin/ble_l2cap_peripheral.rs
@@ -102,9 +102,9 @@ fn main() -> ! {
 
     let config = nrf_softdevice::Config {
         clock: Some(raw::nrf_clock_lf_cfg_t {
-            source: raw::NRF_CLOCK_LF_SRC_XTAL as u8,
-            rc_ctiv: 0,
-            rc_temp_ctiv: 0,
+            source: raw::NRF_CLOCK_LF_SRC_RC as u8,
+            rc_ctiv: 4,
+            rc_temp_ctiv: 2,
             accuracy: 7,
         }),
         conn_gap: Some(raw::ble_gap_conn_cfg_t {

--- a/examples/src/bin/ble_peripheral_onoff.rs
+++ b/examples/src/bin/ble_peripheral_onoff.rs
@@ -132,9 +132,9 @@ fn main() -> ! {
 
     let config = nrf_softdevice::Config {
         clock: Some(raw::nrf_clock_lf_cfg_t {
-            source: raw::NRF_CLOCK_LF_SRC_XTAL as u8,
-            rc_ctiv: 0,
-            rc_temp_ctiv: 0,
+            source: raw::NRF_CLOCK_LF_SRC_RC as u8,
+            rc_ctiv: 4,
+            rc_temp_ctiv: 2,
             accuracy: 7,
         }),
         conn_gap: Some(raw::ble_gap_conn_cfg_t {

--- a/examples/src/bin/ble_scan.rs
+++ b/examples/src/bin/ble_scan.rs
@@ -76,9 +76,9 @@ fn main() -> ! {
 
     let config = nrf_softdevice::Config {
         clock: Some(raw::nrf_clock_lf_cfg_t {
-            source: raw::NRF_CLOCK_LF_SRC_XTAL as u8,
-            rc_ctiv: 0,
-            rc_temp_ctiv: 0,
+            source: raw::NRF_CLOCK_LF_SRC_RC as u8,
+            rc_ctiv: 4,
+            rc_temp_ctiv: 2,
             accuracy: 7,
         }),
         conn_gap: Some(raw::ble_gap_conn_cfg_t {


### PR DESCRIPTION
I'm using a Adafruit Feather nRF52840 Sense and it took a long time to understand that I had to change the clock to the internal rc in the softdevice config.
With the external crystal the examples just got stuck at enable_softdevice without any warning or error.

The internal clock should work on all Boards not only on those  with an external crystal.
