### PR TITLE
Gatt multiple services 1

### DIFF
--- a/examples/src/bin/ble_bas_peripheral.rs
+++ b/examples/src/bin/ble_bas_peripheral.rs
@@ -14,7 +14,7 @@ use defmt::*;
 use embassy::executor::Executor;
 use embassy::util::Forever;
 
-use nrf_softdevice::ble::{gatt_server, peripheral};
+use nrf_softdevice::ble::{gatt_server::{self, Server}, peripheral};
 use nrf_softdevice::{raw, Softdevice};
 
 static EXECUTOR: Forever<Executor> = Forever::new();
@@ -57,27 +57,31 @@ async fn bluetooth_task(sd: &'static Softdevice) {
         info!("advertising done!");
 
         // Run the GATT server on the connection. This returns when the connection gets disconnected.
-        let res = gatt_server::run(&conn, &server, |e| match e {
-            BatteryServiceEvent::BatteryLevelWrite(val) => {
-                info!("wrote battery level: {}", val);
-                if let Err(e) = server.battery_level_notify(&conn, val + 1) {
-                    info!("send notification error: {:?}", e);
+        let res = gatt_server::run(&conn, |e| {
+            server.on_event(&e, |e| match e {
+                BatteryServiceEvent::BatteryLevelWrite(val) => {
+                    info!("wrote battery level: {}", val);
+                    if let Err(e) = server.battery_level_notify(&conn, val + 1) {
+                        info!("send notification error: {:?}", e);
+                    }
                 }
-            }
-            BatteryServiceEvent::FooWrite(val) => {
-                info!("wrote battery level: {}", val);
-                if let Err(e) = server.foo_notify(&conn, val + 1) {
-                    info!("send notification error: {:?}", e);
+                BatteryServiceEvent::FooWrite(val) => {
+                    info!("wrote battery level: {}", val);
+                    if let Err(e) = server.foo_notify(&conn, val + 1) {
+                        info!("send notification error: {:?}", e);
+                    }
                 }
-            }
-            BatteryServiceEvent::BatteryLevelNotificationsEnabled => {
-                info!("battery notifications enabled")
-            }
-            BatteryServiceEvent::BatteryLevelNotificationsDisabled => {
-                info!("battery notifications disabled")
-            }
-            BatteryServiceEvent::FooNotificationsEnabled => info!("foo notifications enabled"),
-            BatteryServiceEvent::FooNotificationsDisabled => info!("foo notifications disabled"),
+                BatteryServiceEvent::BatteryLevelNotificationsEnabled => {
+                    info!("battery notifications enabled")
+                }
+                BatteryServiceEvent::BatteryLevelNotificationsDisabled => {
+                    info!("battery notifications disabled")
+                }
+                BatteryServiceEvent::FooNotificationsEnabled => info!("foo notifications enabled"),
+                BatteryServiceEvent::FooNotificationsDisabled => {
+                    info!("foo notifications disabled")
+                }
+            })
         })
         .await;
 


### PR DESCRIPTION
This is an attempt to fix #73 without using macros. Essentially, the fn run() now handles all events, and emits generic events that the application code can dispatch back to the services.

This feels like an approach that keeps the single service case still simple, while allowing for some flexibility for apps how they want to dispatch events. The ble_bas_peripheral example app have been updated. I can update the other examples if you think this is a viable approach.