### PR TITLE
fix panic in example

### DIFF
--- a/examples/src/bin/ble_l2cap_peripheral.rs
+++ b/examples/src/bin/ble_l2cap_peripheral.rs
@@ -145,9 +145,9 @@ fn main() -> ! {
         ..Default::default()
     };
 
-    unwrap!(RawError::convert(unsafe { raw::sd_clock_hfclk_request() }));
-
     let sd = Softdevice::enable(&config);
+
+    unwrap!(RawError::convert(unsafe { raw::sd_clock_hfclk_request() }));
 
     let executor = EXECUTOR.put(Executor::new());
     executor.run(|spawner| {


### PR DESCRIPTION
This example would previously panic because the softdevice was not enabled.