### PR TITLE
wip: Workaround l2cap credit flow control bug

### DIFF
--- a/nrf-softdevice/Cargo.toml
+++ b/nrf-softdevice/Cargo.toml
@@ -29,6 +29,11 @@ ble-gatt-client = ["ble-gatt"]
 
 critical-section-impl = ["critical-section/custom-impl"]
 
+# Workaround l2cap credit bug. If set, infinite credits are issued
+# to the peer in batches. The `credits` config when establishing the channel is ignored.
+# https://devzone.nordicsemi.com/f/nordic-q-a/81894/s140-7-3-0-softdevice-assertion-failed-at-pc-0xa806-using-l2cap
+ble-l2cap-credit-wrokaround = []
+
 [dependencies]
 defmt = { version = "0.3", optional = true }
 log = { version = "0.4.11", optional = true }


### PR DESCRIPTION
See https://devzone.nordicsemi.com/f/nordic-q-a/81894/s140-7-3-0-softdevice-assertion-failed-at-pc-0xa806-using-l2cap