### PR TITLE
Update toolchain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,9 +70,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "az"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6dff4a1892b54d70af377bf7a17064192e822865791d812957f21e3108c325"
+checksum = "f771a5d1f5503f7f4279a30f3643d3421ba149848b89ecaaec0ea2acf04a5ac4"
 
 [[package]]
 name = "bare-metal"
@@ -109,9 +109,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bytemuck"
-version = "1.7.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72957246c41db82b8ef88a5486143830adeb8227ef9837740bdec67724cf2c5b"
+checksum = "439989e6b8c38d1b6570a384ef1e49c8848128f5a97f3914baef02920842712f"
 
 [[package]]
 name = "byteorder"
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "cortex-m-rt"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069533b58e25b635fac881eb6556616bd8f83a3e0ffe2b4b9619289ed14d465e"
+checksum = "3c433da385b720d5bb9f52362fa2782420798e68d40d67bfe4b0d992aba5dfe7"
 dependencies = [
  "cortex-m-rt-macros",
 ]
@@ -194,12 +194,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "757c0ded2af11d8e739c4daea1ac623dd1624b06c844cf3f5a39f1bdbd99bb12"
+checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
 dependencies = [
- "darling_core 0.13.0",
- "darling_macro 0.13.0",
+ "darling_core 0.13.1",
+ "darling_macro 0.13.1",
 ]
 
 [[package]]
@@ -218,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c34d8efb62d0c2d7f60ece80f75e5c63c1588ba68032740494b0b9a996466e3"
+checksum = "7a340f241d2ceed1deb47ae36c4144b2707ec7dd0b649f894cb39bb595986324"
 dependencies = [
  "fnv",
  "ident_case",
@@ -243,11 +243,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
+checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
 dependencies = [
- "darling_core 0.13.0",
+ "darling_core 0.13.1",
  "quote",
  "syn",
 ]
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dede7fc0d15f4b8e15f3f023aefe6806066d7eb382123981e106fba05b35c5a3"
+checksum = "098396b763a1786b329405f69bc3677e00d45eb4534bc9f31cd23011ee2ba267"
 dependencies = [
  "defmt-parser",
  "proc-macro-error",
@@ -295,7 +295,7 @@ dependencies = [
 [[package]]
 name = "embassy"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#271881533e104d4f1f1225a6251da2eea8269470"
+source = "git+https://github.com/embassy-rs/embassy#79cbad501c6e6166d0e53ab33b2401a674ee9f31"
 dependencies = [
  "atomic-polyfill",
  "cortex-m 0.7.3",
@@ -312,7 +312,7 @@ dependencies = [
 [[package]]
 name = "embassy-hal-common"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#271881533e104d4f1f1225a6251da2eea8269470"
+source = "git+https://github.com/embassy-rs/embassy#79cbad501c6e6166d0e53ab33b2401a674ee9f31"
 dependencies = [
  "cortex-m 0.7.3",
  "embassy",
@@ -323,9 +323,9 @@ dependencies = [
 [[package]]
 name = "embassy-macros"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#271881533e104d4f1f1225a6251da2eea8269470"
+source = "git+https://github.com/embassy-rs/embassy#79cbad501c6e6166d0e53ab33b2401a674ee9f31"
 dependencies = [
- "darling 0.13.0",
+ "darling 0.13.1",
  "proc-macro2",
  "quote",
  "syn",
@@ -334,7 +334,7 @@ dependencies = [
 [[package]]
 name = "embassy-nrf"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#271881533e104d4f1f1225a6251da2eea8269470"
+source = "git+https://github.com/embassy-rs/embassy#79cbad501c6e6166d0e53ab33b2401a674ee9f31"
 dependencies = [
  "cfg-if",
  "cortex-m 0.7.3",
@@ -356,7 +356,7 @@ dependencies = [
 [[package]]
 name = "embassy-traits"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#271881533e104d4f1f1225a6251da2eea8269470"
+source = "git+https://github.com/embassy-rs/embassy#79cbad501c6e6166d0e53ab33b2401a674ee9f31"
 dependencies = [
  "defmt",
  "embedded-hal",
@@ -389,9 +389,9 @@ checksum = "723dce4e9f25b6e6c5f35628e144794e5b459216ed7da97b7c4b66cdb3fa82ca"
 
 [[package]]
 name = "fixed"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d333a26ec13a023c6dff4b7584de4d323cfee2e508f5dd2bbee6669e4f7efdf"
+checksum = "80a9a8cb2e34880a498f09367089339bda5e12d6f871640f947850f7113058c0"
 dependencies = [
  "az",
  "bytemuck",
@@ -407,9 +407,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
+checksum = "28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -421,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
+checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -431,35 +431,34 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
 
 [[package]]
 name = "futures-io"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
+checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
+checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
 
 [[package]]
 name = "futures-task"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
+checksum = "6ee7c6485c30167ce4dfb83ac568a849fe53274c831081476ee13e0dce1aad72"
 
 [[package]]
 name = "futures-util"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
 dependencies = [
- "autocfg",
  "futures-core",
  "futures-sink",
  "futures-task",
@@ -512,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1ad878e07405df82b695089e63d278244344f80e764074d0bdfe99b89460f3"
+checksum = "7e476c64197665c3725621f0ac3f9e5209aa5e889e02a08b1daf5f16dc5fd952"
 dependencies = [
  "atomic-polyfill",
  "hash32",
@@ -589,6 +588,7 @@ dependencies = [
  "defmt",
  "embassy",
  "fixed",
+ "futures",
  "heapless",
  "log",
  "nrf-softdevice-macro",
@@ -761,9 +761,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9bd055fb730c4f8f4f57d45d35cd6b3f0980535b056dc7ff119cee6a66ed6f"
+checksum = "085fe377a4b2805c0fbc09484415ec261174614b7f080b0e0d520456ac421a67"
 dependencies = [
  "derivative",
  "num_enum_derive",
@@ -771,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486ea01961c4a818096de679a8b740b26d9033146ac5291b1c98557658f8cdd9"
+checksum = "5249369707a1e07b39f78d98c8f34e00aca7dcb053812fdbb5ad7be82c1bba38"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -848,9 +848,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
 dependencies = [
  "unicode-xid",
 ]
@@ -967,9 +967,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
+checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ pub unsafe fn sd_ble_gap_connect(
       conn_cfg_tag: u8,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 140",
+    core::arch::asm!("svc 140",
         inout("r0") p_peer_addr => res,
         inout("r1") p_scan_params => _,
         inout("r2") p_conn_params => _,

--- a/examples/src/bin/ble_l2cap_central.rs
+++ b/examples/src/bin/ble_l2cap_central.rs
@@ -12,8 +12,7 @@ use core::mem;
 use core::ptr::NonNull;
 use core::slice;
 use cortex_m_rt::entry;
-use defmt::info;
-use defmt::{unreachable, *};
+use defmt::{info, *};
 use embassy::executor::Executor;
 use embassy::util::Forever;
 

--- a/examples/src/bin/ble_peripheral_onoff.rs
+++ b/examples/src/bin/ble_peripheral_onoff.rs
@@ -14,7 +14,6 @@ use embassy::executor::Executor;
 use embassy::traits::gpio::WaitForLow;
 use embassy::util::Forever;
 use embassy_nrf::gpio::{AnyPin, Input, Pin as _, Pull};
-use embassy_nrf::gpiote::PortInput;
 use embassy_nrf::interrupt::Priority;
 use futures::pin_mut;
 
@@ -87,8 +86,8 @@ async fn bluetooth_task(sd: &'static Softdevice, button1: AnyPin, button2: AnyPi
     info!("Bluetooth is OFF");
     info!("Press nrf52840-dk button 1 to enable, button 2 to disable");
 
-    let button1 = PortInput::new(Input::new(button1, Pull::Up));
-    let button2 = PortInput::new(Input::new(button2, Pull::Up));
+    let button1 = Input::new(button1, Pull::Up);
+    let button2 = Input::new(button2, Pull::Up);
     pin_mut!(button1);
     pin_mut!(button2);
     loop {

--- a/nrf-softdevice-gen/src/main.rs
+++ b/nrf-softdevice-gen/src/main.rs
@@ -130,7 +130,7 @@ fn main() {
             .collect::<Vec<&str>>();
 
         writeln!(&mut res, "    let ret: u32;",).unwrap();
-        writeln!(&mut res, "    asm!(\"svc {}\",", num).unwrap();
+        writeln!(&mut res, "    core::arch::asm!(\"svc {}\",", num).unwrap();
 
         assert!(arg_names.len() <= 4);
         for r in 0..4 {

--- a/nrf-softdevice-mbr/src/bindings.rs
+++ b/nrf-softdevice-mbr/src/bindings.rs
@@ -620,7 +620,7 @@ fn bindgen_test_layout_sd_mbr_command_t() {
 #[inline(always)]
 pub unsafe fn sd_mbr_command(param: *mut sd_mbr_command_t) -> u32 {
     let ret: u32;
-    asm!("svc 24",
+    core::arch::asm!("svc 24",
         inout("r0") to_asm(param) => ret,
         lateout("r1") _,
         lateout("r2") _,

--- a/nrf-softdevice-mbr/src/lib.rs
+++ b/nrf-softdevice-mbr/src/lib.rs
@@ -3,7 +3,6 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_snake_case)]
 #![allow(dead_code)]
-#![feature(asm)]
 
 mod bindings;
 

--- a/nrf-softdevice-s112/src/bindings.rs
+++ b/nrf-softdevice-s112/src/bindings.rs
@@ -1621,7 +1621,7 @@ fn bindgen_test_layout_nrf_ecb_hal_data_block_t() {
 #[inline(always)]
 pub unsafe fn sd_mutex_new(p_mutex: *mut nrf_mutex_t) -> u32 {
     let ret: u32;
-    asm!("svc 44",
+    core::arch::asm!("svc 44",
         inout("r0") to_asm(p_mutex) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1640,7 +1640,7 @@ pub unsafe fn sd_mutex_new(p_mutex: *mut nrf_mutex_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_mutex_acquire(p_mutex: *mut nrf_mutex_t) -> u32 {
     let ret: u32;
-    asm!("svc 45",
+    core::arch::asm!("svc 45",
         inout("r0") to_asm(p_mutex) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1658,7 +1658,7 @@ pub unsafe fn sd_mutex_acquire(p_mutex: *mut nrf_mutex_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_mutex_release(p_mutex: *mut nrf_mutex_t) -> u32 {
     let ret: u32;
-    asm!("svc 46",
+    core::arch::asm!("svc 46",
         inout("r0") to_asm(p_mutex) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1676,7 +1676,7 @@ pub unsafe fn sd_mutex_release(p_mutex: *mut nrf_mutex_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_rand_application_pool_capacity_get(p_pool_capacity: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 47",
+    core::arch::asm!("svc 47",
         inout("r0") to_asm(p_pool_capacity) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1694,7 +1694,7 @@ pub unsafe fn sd_rand_application_pool_capacity_get(p_pool_capacity: *mut u8) ->
 #[inline(always)]
 pub unsafe fn sd_rand_application_bytes_available_get(p_bytes_available: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 48",
+    core::arch::asm!("svc 48",
         inout("r0") to_asm(p_bytes_available) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1714,7 +1714,7 @@ pub unsafe fn sd_rand_application_bytes_available_get(p_bytes_available: *mut u8
 #[inline(always)]
 pub unsafe fn sd_rand_application_vector_get(p_buff: *mut u8, length: u8) -> u32 {
     let ret: u32;
-    asm!("svc 49",
+    core::arch::asm!("svc 49",
         inout("r0") to_asm(p_buff) => ret,
         inout("r1") to_asm(length) => _,
         lateout("r2") _,
@@ -1732,7 +1732,7 @@ pub unsafe fn sd_rand_application_vector_get(p_buff: *mut u8, length: u8) -> u32
 #[inline(always)]
 pub unsafe fn sd_power_reset_reason_get(p_reset_reason: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 52",
+    core::arch::asm!("svc 52",
         inout("r0") to_asm(p_reset_reason) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1750,7 +1750,7 @@ pub unsafe fn sd_power_reset_reason_get(p_reset_reason: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_reset_reason_clr(reset_reason_clr_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 53",
+    core::arch::asm!("svc 53",
         inout("r0") to_asm(reset_reason_clr_msk) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1769,7 +1769,7 @@ pub unsafe fn sd_power_reset_reason_clr(reset_reason_clr_msk: u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_mode_set(power_mode: u8) -> u32 {
     let ret: u32;
-    asm!("svc 50",
+    core::arch::asm!("svc 50",
         inout("r0") to_asm(power_mode) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1785,7 +1785,7 @@ pub unsafe fn sd_power_mode_set(power_mode: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_system_off() -> u32 {
     let ret: u32;
-    asm!("svc 51",
+    core::arch::asm!("svc 51",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1806,7 +1806,7 @@ pub unsafe fn sd_power_system_off() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_pof_enable(pof_enable: u8) -> u32 {
     let ret: u32;
-    asm!("svc 54",
+    core::arch::asm!("svc 54",
         inout("r0") to_asm(pof_enable) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1826,7 +1826,7 @@ pub unsafe fn sd_power_pof_enable(pof_enable: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_pof_threshold_set(threshold: u8) -> u32 {
     let ret: u32;
-    asm!("svc 55",
+    core::arch::asm!("svc 55",
         inout("r0") to_asm(threshold) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1845,7 +1845,7 @@ pub unsafe fn sd_power_pof_threshold_set(threshold: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_ram_power_set(index: u8, ram_powerset: u32) -> u32 {
     let ret: u32;
-    asm!("svc 57",
+    core::arch::asm!("svc 57",
         inout("r0") to_asm(index) => ret,
         inout("r1") to_asm(ram_powerset) => _,
         lateout("r2") _,
@@ -1864,7 +1864,7 @@ pub unsafe fn sd_power_ram_power_set(index: u8, ram_powerset: u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_ram_power_clr(index: u8, ram_powerclr: u32) -> u32 {
     let ret: u32;
-    asm!("svc 58",
+    core::arch::asm!("svc 58",
         inout("r0") to_asm(index) => ret,
         inout("r1") to_asm(ram_powerclr) => _,
         lateout("r2") _,
@@ -1883,7 +1883,7 @@ pub unsafe fn sd_power_ram_power_clr(index: u8, ram_powerclr: u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_ram_power_get(index: u8, p_ram_power: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 59",
+    core::arch::asm!("svc 59",
         inout("r0") to_asm(index) => ret,
         inout("r1") to_asm(p_ram_power) => _,
         lateout("r2") _,
@@ -1902,7 +1902,7 @@ pub unsafe fn sd_power_ram_power_get(index: u8, p_ram_power: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_gpregret_set(gpregret_id: u32, gpregret_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 60",
+    core::arch::asm!("svc 60",
         inout("r0") to_asm(gpregret_id) => ret,
         inout("r1") to_asm(gpregret_msk) => _,
         lateout("r2") _,
@@ -1921,7 +1921,7 @@ pub unsafe fn sd_power_gpregret_set(gpregret_id: u32, gpregret_msk: u32) -> u32 
 #[inline(always)]
 pub unsafe fn sd_power_gpregret_clr(gpregret_id: u32, gpregret_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 61",
+    core::arch::asm!("svc 61",
         inout("r0") to_asm(gpregret_id) => ret,
         inout("r1") to_asm(gpregret_msk) => _,
         lateout("r2") _,
@@ -1940,7 +1940,7 @@ pub unsafe fn sd_power_gpregret_clr(gpregret_id: u32, gpregret_msk: u32) -> u32 
 #[inline(always)]
 pub unsafe fn sd_power_gpregret_get(gpregret_id: u32, p_gpregret: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 62",
+    core::arch::asm!("svc 62",
         inout("r0") to_asm(gpregret_id) => ret,
         inout("r1") to_asm(p_gpregret) => _,
         lateout("r2") _,
@@ -1959,7 +1959,7 @@ pub unsafe fn sd_power_gpregret_get(gpregret_id: u32, p_gpregret: *mut u32) -> u
 #[inline(always)]
 pub unsafe fn sd_power_dcdc_mode_set(dcdc_mode: u8) -> u32 {
     let ret: u32;
-    asm!("svc 63",
+    core::arch::asm!("svc 63",
         inout("r0") to_asm(dcdc_mode) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1981,7 +1981,7 @@ pub unsafe fn sd_power_dcdc_mode_set(dcdc_mode: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_clock_hfclk_request() -> u32 {
     let ret: u32;
-    asm!("svc 66",
+    core::arch::asm!("svc 66",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2002,7 +2002,7 @@ pub unsafe fn sd_clock_hfclk_request() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_clock_hfclk_release() -> u32 {
     let ret: u32;
-    asm!("svc 67",
+    core::arch::asm!("svc 67",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2023,7 +2023,7 @@ pub unsafe fn sd_clock_hfclk_release() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_clock_hfclk_is_running(p_is_running: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 68",
+    core::arch::asm!("svc 68",
         inout("r0") to_asm(p_is_running) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2061,7 +2061,7 @@ pub unsafe fn sd_clock_hfclk_is_running(p_is_running: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_app_evt_wait() -> u32 {
     let ret: u32;
-    asm!("svc 65",
+    core::arch::asm!("svc 65",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2079,7 +2079,7 @@ pub unsafe fn sd_app_evt_wait() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_channel_enable_get(p_channel_enable: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 32",
+    core::arch::asm!("svc 32",
         inout("r0") to_asm(p_channel_enable) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2097,7 +2097,7 @@ pub unsafe fn sd_ppi_channel_enable_get(p_channel_enable: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_channel_enable_set(channel_enable_set_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 33",
+    core::arch::asm!("svc 33",
         inout("r0") to_asm(channel_enable_set_msk) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2115,7 +2115,7 @@ pub unsafe fn sd_ppi_channel_enable_set(channel_enable_set_msk: u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_channel_enable_clr(channel_enable_clr_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 34",
+    core::arch::asm!("svc 34",
         inout("r0") to_asm(channel_enable_clr_msk) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2140,7 +2140,7 @@ pub unsafe fn sd_ppi_channel_assign(
     task_endpoint: *const self::c_void,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 35",
+    core::arch::asm!("svc 35",
         inout("r0") to_asm(channel_num) => ret,
         inout("r1") to_asm(evt_endpoint) => _,
         inout("r2") to_asm(task_endpoint) => _,
@@ -2159,7 +2159,7 @@ pub unsafe fn sd_ppi_channel_assign(
 #[inline(always)]
 pub unsafe fn sd_ppi_group_task_enable(group_num: u8) -> u32 {
     let ret: u32;
-    asm!("svc 36",
+    core::arch::asm!("svc 36",
         inout("r0") to_asm(group_num) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2178,7 +2178,7 @@ pub unsafe fn sd_ppi_group_task_enable(group_num: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_group_task_disable(group_num: u8) -> u32 {
     let ret: u32;
-    asm!("svc 37",
+    core::arch::asm!("svc 37",
         inout("r0") to_asm(group_num) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2198,7 +2198,7 @@ pub unsafe fn sd_ppi_group_task_disable(group_num: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_group_assign(group_num: u8, channel_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 38",
+    core::arch::asm!("svc 38",
         inout("r0") to_asm(group_num) => ret,
         inout("r1") to_asm(channel_msk) => _,
         lateout("r2") _,
@@ -2218,7 +2218,7 @@ pub unsafe fn sd_ppi_group_assign(group_num: u8, channel_msk: u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_group_get(group_num: u8, p_channel_msk: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 39",
+    core::arch::asm!("svc 39",
         inout("r0") to_asm(group_num) => ret,
         inout("r1") to_asm(p_channel_msk) => _,
         lateout("r2") _,
@@ -2259,7 +2259,7 @@ pub unsafe fn sd_ppi_group_get(group_num: u8, p_channel_msk: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_radio_notification_cfg_set(type_: u8, distance: u8) -> u32 {
     let ret: u32;
-    asm!("svc 69",
+    core::arch::asm!("svc 69",
         inout("r0") to_asm(type_) => ret,
         inout("r1") to_asm(distance) => _,
         lateout("r2") _,
@@ -2285,7 +2285,7 @@ pub unsafe fn sd_radio_notification_cfg_set(type_: u8, distance: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ecb_block_encrypt(p_ecb_data: *mut nrf_ecb_hal_data_t) -> u32 {
     let ret: u32;
-    asm!("svc 70",
+    core::arch::asm!("svc 70",
         inout("r0") to_asm(p_ecb_data) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2315,7 +2315,7 @@ pub unsafe fn sd_ecb_blocks_encrypt(
     p_data_blocks: *mut nrf_ecb_hal_data_block_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 71",
+    core::arch::asm!("svc 71",
         inout("r0") to_asm(block_count) => ret,
         inout("r1") to_asm(p_data_blocks) => _,
         lateout("r2") _,
@@ -2336,7 +2336,7 @@ pub unsafe fn sd_ecb_blocks_encrypt(
 #[inline(always)]
 pub unsafe fn sd_evt_get(p_evt_id: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 75",
+    core::arch::asm!("svc 75",
         inout("r0") to_asm(p_evt_id) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2357,7 +2357,7 @@ pub unsafe fn sd_evt_get(p_evt_id: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_temp_get(p_temp: *mut i32) -> u32 {
     let ret: u32;
-    asm!("svc 76",
+    core::arch::asm!("svc 76",
         inout("r0") to_asm(p_temp) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2404,7 +2404,7 @@ pub unsafe fn sd_temp_get(p_temp: *mut i32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_flash_write(p_dst: *mut u32, p_src: *const u32, size: u32) -> u32 {
     let ret: u32;
-    asm!("svc 41",
+    core::arch::asm!("svc 41",
         inout("r0") to_asm(p_dst) => ret,
         inout("r1") to_asm(p_src) => _,
         inout("r2") to_asm(size) => _,
@@ -2445,7 +2445,7 @@ pub unsafe fn sd_flash_write(p_dst: *mut u32, p_src: *const u32, size: u32) -> u
 #[inline(always)]
 pub unsafe fn sd_flash_page_erase(page_number: u32) -> u32 {
     let ret: u32;
-    asm!("svc 40",
+    core::arch::asm!("svc 40",
         inout("r0") to_asm(page_number) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2482,7 +2482,7 @@ pub unsafe fn sd_flash_protect(
     block_cfg3: u32,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 42",
+    core::arch::asm!("svc 42",
         inout("r0") to_asm(block_cfg0) => ret,
         inout("r1") to_asm(block_cfg1) => _,
         inout("r2") to_asm(block_cfg2) => _,
@@ -2514,7 +2514,7 @@ pub unsafe fn sd_flash_protect(
 #[inline(always)]
 pub unsafe fn sd_radio_session_open(p_radio_signal_callback: nrf_radio_signal_callback_t) -> u32 {
     let ret: u32;
-    asm!("svc 72",
+    core::arch::asm!("svc 72",
         inout("r0") to_asm(p_radio_signal_callback) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2537,7 +2537,7 @@ pub unsafe fn sd_radio_session_open(p_radio_signal_callback: nrf_radio_signal_ca
 #[inline(always)]
 pub unsafe fn sd_radio_session_close() -> u32 {
     let ret: u32;
-    asm!("svc 73",
+    core::arch::asm!("svc 73",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2584,7 +2584,7 @@ pub unsafe fn sd_radio_session_close() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_radio_request(p_request: *const nrf_radio_request_t) -> u32 {
     let ret: u32;
-    asm!("svc 74",
+    core::arch::asm!("svc 74",
         inout("r0") to_asm(p_request) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2615,7 +2615,7 @@ pub unsafe fn sd_radio_request(p_request: *const nrf_radio_request_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_protected_register_write(p_register: *mut u32, value: u32) -> u32 {
     let ret: u32;
-    asm!("svc 43",
+    core::arch::asm!("svc 43",
         inout("r0") to_asm(p_register) => ret,
         inout("r1") to_asm(value) => _,
         lateout("r2") _,
@@ -2785,7 +2785,7 @@ pub unsafe fn sd_softdevice_enable(
     fault_handler: nrf_fault_handler_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 16",
+    core::arch::asm!("svc 16",
         inout("r0") to_asm(p_clock_lf_cfg) => ret,
         inout("r1") to_asm(fault_handler) => _,
         lateout("r2") _,
@@ -2810,7 +2810,7 @@ pub unsafe fn sd_softdevice_enable(
 #[inline(always)]
 pub unsafe fn sd_softdevice_disable() -> u32 {
     let ret: u32;
-    asm!("svc 17",
+    core::arch::asm!("svc 17",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2828,7 +2828,7 @@ pub unsafe fn sd_softdevice_disable() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_softdevice_is_enabled(p_softdevice_enabled: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 18",
+    core::arch::asm!("svc 18",
         inout("r0") to_asm(p_softdevice_enabled) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2848,7 +2848,7 @@ pub unsafe fn sd_softdevice_is_enabled(p_softdevice_enabled: *mut u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_softdevice_vector_table_base_set(address: u32) -> u32 {
     let ret: u32;
-    asm!("svc 19",
+    core::arch::asm!("svc 19",
         inout("r0") to_asm(address) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -3676,7 +3676,7 @@ fn bindgen_test_layout_sd_mbr_command_t() {
 #[inline(always)]
 pub unsafe fn sd_mbr_command(param: *mut sd_mbr_command_t) -> u32 {
     let ret: u32;
-    asm!("svc 24",
+    core::arch::asm!("svc 24",
         inout("r0") to_asm(param) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -7659,7 +7659,7 @@ fn bindgen_test_layout_ble_gap_opt_t() {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_addr_set(p_addr: *const ble_gap_addr_t) -> u32 {
     let ret: u32;
-    asm!("svc 108",
+    core::arch::asm!("svc 108",
         inout("r0") to_asm(p_addr) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -7681,7 +7681,7 @@ pub unsafe fn sd_ble_gap_addr_set(p_addr: *const ble_gap_addr_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_addr_get(p_addr: *mut ble_gap_addr_t) -> u32 {
     let ret: u32;
-    asm!("svc 109",
+    core::arch::asm!("svc 109",
         inout("r0") to_asm(p_addr) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -7709,7 +7709,7 @@ pub unsafe fn sd_ble_gap_addr_get(p_addr: *mut ble_gap_addr_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_adv_addr_get(adv_handle: u8, p_addr: *mut ble_gap_addr_t) -> u32 {
     let ret: u32;
-    asm!("svc 147",
+    core::arch::asm!("svc 147",
         inout("r0") to_asm(adv_handle) => ret,
         inout("r1") to_asm(p_addr) => _,
         lateout("r2") _,
@@ -7739,7 +7739,7 @@ pub unsafe fn sd_ble_gap_adv_addr_get(adv_handle: u8, p_addr: *mut ble_gap_addr_
 #[inline(always)]
 pub unsafe fn sd_ble_gap_whitelist_set(pp_wl_addrs: *const *const ble_gap_addr_t, len: u8) -> u32 {
     let ret: u32;
-    asm!("svc 110",
+    core::arch::asm!("svc 110",
         inout("r0") to_asm(pp_wl_addrs) => ret,
         inout("r1") to_asm(len) => _,
         lateout("r2") _,
@@ -7780,7 +7780,7 @@ pub unsafe fn sd_ble_gap_device_identities_set(
     len: u8,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 111",
+    core::arch::asm!("svc 111",
         inout("r0") to_asm(pp_id_keys) => ret,
         inout("r1") to_asm(pp_local_irks) => _,
         inout("r2") to_asm(len) => _,
@@ -7811,7 +7811,7 @@ pub unsafe fn sd_ble_gap_device_identities_set(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_privacy_set(p_privacy_params: *const ble_gap_privacy_params_t) -> u32 {
     let ret: u32;
-    asm!("svc 112",
+    core::arch::asm!("svc 112",
         inout("r0") to_asm(p_privacy_params) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -7834,7 +7834,7 @@ pub unsafe fn sd_ble_gap_privacy_set(p_privacy_params: *const ble_gap_privacy_pa
 #[inline(always)]
 pub unsafe fn sd_ble_gap_privacy_get(p_privacy_params: *mut ble_gap_privacy_params_t) -> u32 {
     let ret: u32;
-    asm!("svc 113",
+    core::arch::asm!("svc 113",
         inout("r0") to_asm(p_privacy_params) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -7893,7 +7893,7 @@ pub unsafe fn sd_ble_gap_adv_set_configure(
     p_adv_params: *const ble_gap_adv_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 114",
+    core::arch::asm!("svc 114",
         inout("r0") to_asm(p_adv_handle) => ret,
         inout("r1") to_asm(p_adv_data) => _,
         inout("r2") to_asm(p_adv_params) => _,
@@ -7948,7 +7948,7 @@ pub unsafe fn sd_ble_gap_adv_set_configure(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_adv_start(adv_handle: u8, conn_cfg_tag: u8) -> u32 {
     let ret: u32;
-    asm!("svc 115",
+    core::arch::asm!("svc 115",
         inout("r0") to_asm(adv_handle) => ret,
         inout("r1") to_asm(conn_cfg_tag) => _,
         lateout("r2") _,
@@ -7972,7 +7972,7 @@ pub unsafe fn sd_ble_gap_adv_start(adv_handle: u8, conn_cfg_tag: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_adv_stop(adv_handle: u8) -> u32 {
     let ret: u32;
-    asm!("svc 116",
+    core::arch::asm!("svc 116",
         inout("r0") to_asm(adv_handle) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -8013,7 +8013,7 @@ pub unsafe fn sd_ble_gap_conn_param_update(
     p_conn_params: *const ble_gap_conn_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 117",
+    core::arch::asm!("svc 117",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_conn_params) => _,
         lateout("r2") _,
@@ -8046,7 +8046,7 @@ pub unsafe fn sd_ble_gap_conn_param_update(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_disconnect(conn_handle: u16, hci_status_code: u8) -> u32 {
     let ret: u32;
-    asm!("svc 118",
+    core::arch::asm!("svc 118",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(hci_status_code) => _,
         lateout("r2") _,
@@ -8080,7 +8080,7 @@ pub unsafe fn sd_ble_gap_disconnect(conn_handle: u16, hci_status_code: u8) -> u3
 #[inline(always)]
 pub unsafe fn sd_ble_gap_tx_power_set(role: u8, handle: u16, tx_power: i8) -> u32 {
     let ret: u32;
-    asm!("svc 119",
+    core::arch::asm!("svc 119",
         inout("r0") to_asm(role) => ret,
         inout("r1") to_asm(handle) => _,
         inout("r2") to_asm(tx_power) => _,
@@ -8099,7 +8099,7 @@ pub unsafe fn sd_ble_gap_tx_power_set(role: u8, handle: u16, tx_power: i8) -> u3
 #[inline(always)]
 pub unsafe fn sd_ble_gap_appearance_set(appearance: u16) -> u32 {
     let ret: u32;
-    asm!("svc 120",
+    core::arch::asm!("svc 120",
         inout("r0") to_asm(appearance) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -8118,7 +8118,7 @@ pub unsafe fn sd_ble_gap_appearance_set(appearance: u16) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_appearance_get(p_appearance: *mut u16) -> u32 {
     let ret: u32;
-    asm!("svc 121",
+    core::arch::asm!("svc 121",
         inout("r0") to_asm(p_appearance) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -8140,7 +8140,7 @@ pub unsafe fn sd_ble_gap_appearance_get(p_appearance: *mut u16) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_ppcp_set(p_conn_params: *const ble_gap_conn_params_t) -> u32 {
     let ret: u32;
-    asm!("svc 122",
+    core::arch::asm!("svc 122",
         inout("r0") to_asm(p_conn_params) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -8161,7 +8161,7 @@ pub unsafe fn sd_ble_gap_ppcp_set(p_conn_params: *const ble_gap_conn_params_t) -
 #[inline(always)]
 pub unsafe fn sd_ble_gap_ppcp_get(p_conn_params: *mut ble_gap_conn_params_t) -> u32 {
     let ret: u32;
-    asm!("svc 123",
+    core::arch::asm!("svc 123",
         inout("r0") to_asm(p_conn_params) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -8192,7 +8192,7 @@ pub unsafe fn sd_ble_gap_device_name_set(
     len: u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 124",
+    core::arch::asm!("svc 124",
         inout("r0") to_asm(p_write_perm) => ret,
         inout("r1") to_asm(p_dev_name) => _,
         inout("r2") to_asm(len) => _,
@@ -8218,7 +8218,7 @@ pub unsafe fn sd_ble_gap_device_name_set(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_device_name_get(p_dev_name: *mut u8, p_len: *mut u16) -> u32 {
     let ret: u32;
-    asm!("svc 125",
+    core::arch::asm!("svc 125",
         inout("r0") to_asm(p_dev_name) => ret,
         inout("r1") to_asm(p_len) => _,
         lateout("r2") _,
@@ -8267,7 +8267,7 @@ pub unsafe fn sd_ble_gap_authenticate(
     p_sec_params: *const ble_gap_sec_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 126",
+    core::arch::asm!("svc 126",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_sec_params) => _,
         lateout("r2") _,
@@ -8330,7 +8330,7 @@ pub unsafe fn sd_ble_gap_sec_params_reply(
     p_sec_keyset: *const ble_gap_sec_keyset_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 127",
+    core::arch::asm!("svc 127",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(sec_status) => _,
         inout("r2") to_asm(p_sec_params) => _,
@@ -8370,7 +8370,7 @@ pub unsafe fn sd_ble_gap_sec_params_reply(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_auth_key_reply(conn_handle: u16, key_type: u8, p_key: *const u8) -> u32 {
     let ret: u32;
-    asm!("svc 128",
+    core::arch::asm!("svc 128",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(key_type) => _,
         inout("r2") to_asm(p_key) => _,
@@ -8413,7 +8413,7 @@ pub unsafe fn sd_ble_gap_lesc_dhkey_reply(
     p_dhkey: *const ble_gap_lesc_dhkey_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 129",
+    core::arch::asm!("svc 129",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_dhkey) => _,
         lateout("r2") _,
@@ -8443,7 +8443,7 @@ pub unsafe fn sd_ble_gap_lesc_dhkey_reply(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_keypress_notify(conn_handle: u16, kp_not: u8) -> u32 {
     let ret: u32;
-    asm!("svc 130",
+    core::arch::asm!("svc 130",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(kp_not) => _,
         lateout("r2") _,
@@ -8476,7 +8476,7 @@ pub unsafe fn sd_ble_gap_lesc_oob_data_get(
     p_oobd_own: *mut ble_gap_lesc_oob_data_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 131",
+    core::arch::asm!("svc 131",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_pk_own) => _,
         inout("r2") to_asm(p_oobd_own) => _,
@@ -8520,7 +8520,7 @@ pub unsafe fn sd_ble_gap_lesc_oob_data_set(
     p_oobd_peer: *const ble_gap_lesc_oob_data_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 132",
+    core::arch::asm!("svc 132",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_oobd_own) => _,
         inout("r2") to_asm(p_oobd_peer) => _,
@@ -8560,7 +8560,7 @@ pub unsafe fn sd_ble_gap_sec_info_reply(
     p_sign_info: *const ble_gap_sign_info_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 134",
+    core::arch::asm!("svc 134",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_enc_info) => _,
         inout("r2") to_asm(p_id_info) => _,
@@ -8584,7 +8584,7 @@ pub unsafe fn sd_ble_gap_conn_sec_get(
     p_conn_sec: *mut ble_gap_conn_sec_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 135",
+    core::arch::asm!("svc 135",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_conn_sec) => _,
         lateout("r2") _,
@@ -8619,7 +8619,7 @@ pub unsafe fn sd_ble_gap_conn_sec_get(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_rssi_start(conn_handle: u16, threshold_dbm: u8, skip_count: u8) -> u32 {
     let ret: u32;
-    asm!("svc 136",
+    core::arch::asm!("svc 136",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(threshold_dbm) => _,
         inout("r2") to_asm(skip_count) => _,
@@ -8647,7 +8647,7 @@ pub unsafe fn sd_ble_gap_rssi_start(conn_handle: u16, threshold_dbm: u8, skip_co
 #[inline(always)]
 pub unsafe fn sd_ble_gap_rssi_stop(conn_handle: u16) -> u32 {
     let ret: u32;
-    asm!("svc 137",
+    core::arch::asm!("svc 137",
         inout("r0") to_asm(conn_handle) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -8677,7 +8677,7 @@ pub unsafe fn sd_ble_gap_rssi_stop(conn_handle: u16) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_rssi_get(conn_handle: u16, p_rssi: *mut i8, p_ch_index: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 142",
+    core::arch::asm!("svc 142",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_rssi) => _,
         inout("r2") to_asm(p_ch_index) => _,
@@ -8737,7 +8737,7 @@ pub unsafe fn sd_ble_gap_rssi_get(conn_handle: u16, p_rssi: *mut i8, p_ch_index:
 #[inline(always)]
 pub unsafe fn sd_ble_gap_phy_update(conn_handle: u16, p_gap_phys: *const ble_gap_phys_t) -> u32 {
     let ret: u32;
-    asm!("svc 143",
+    core::arch::asm!("svc 143",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_gap_phys) => _,
         lateout("r2") _,
@@ -8770,7 +8770,7 @@ pub unsafe fn sd_ble_gap_phy_update(conn_handle: u16, p_gap_phys: *const ble_gap
 #[inline(always)]
 pub unsafe fn sd_ble_gap_next_conn_evt_counter_get(conn_handle: u16, p_counter: *mut u16) -> u32 {
     let ret: u32;
-    asm!("svc 148",
+    core::arch::asm!("svc 148",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_counter) => _,
         lateout("r2") _,
@@ -10435,7 +10435,7 @@ pub unsafe fn sd_ble_gattc_primary_services_discover(
     p_srvc_uuid: *const ble_uuid_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 155",
+    core::arch::asm!("svc 155",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(start_handle) => _,
         inout("r2") to_asm(p_srvc_uuid) => _,
@@ -10474,7 +10474,7 @@ pub unsafe fn sd_ble_gattc_relationships_discover(
     p_handle_range: *const ble_gattc_handle_range_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 156",
+    core::arch::asm!("svc 156",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_handle_range) => _,
         lateout("r2") _,
@@ -10515,7 +10515,7 @@ pub unsafe fn sd_ble_gattc_characteristics_discover(
     p_handle_range: *const ble_gattc_handle_range_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 157",
+    core::arch::asm!("svc 157",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_handle_range) => _,
         lateout("r2") _,
@@ -10553,7 +10553,7 @@ pub unsafe fn sd_ble_gattc_descriptors_discover(
     p_handle_range: *const ble_gattc_handle_range_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 158",
+    core::arch::asm!("svc 158",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_handle_range) => _,
         lateout("r2") _,
@@ -10593,7 +10593,7 @@ pub unsafe fn sd_ble_gattc_char_value_by_uuid_read(
     p_handle_range: *const ble_gattc_handle_range_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 160",
+    core::arch::asm!("svc 160",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_uuid) => _,
         inout("r2") to_asm(p_handle_range) => _,
@@ -10629,7 +10629,7 @@ pub unsafe fn sd_ble_gattc_char_value_by_uuid_read(
 #[inline(always)]
 pub unsafe fn sd_ble_gattc_read(conn_handle: u16, handle: u16, offset: u16) -> u32 {
     let ret: u32;
-    asm!("svc 161",
+    core::arch::asm!("svc 161",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(handle) => _,
         inout("r2") to_asm(offset) => _,
@@ -10668,7 +10668,7 @@ pub unsafe fn sd_ble_gattc_char_values_read(
     handle_count: u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 162",
+    core::arch::asm!("svc 162",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_handles) => _,
         inout("r2") to_asm(handle_count) => _,
@@ -10727,7 +10727,7 @@ pub unsafe fn sd_ble_gattc_write(
     p_write_params: *const ble_gattc_write_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 163",
+    core::arch::asm!("svc 163",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_write_params) => _,
         lateout("r2") _,
@@ -10754,7 +10754,7 @@ pub unsafe fn sd_ble_gattc_write(
 #[inline(always)]
 pub unsafe fn sd_ble_gattc_hv_confirm(conn_handle: u16, handle: u16) -> u32 {
     let ret: u32;
-    asm!("svc 164",
+    core::arch::asm!("svc 164",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(handle) => _,
         lateout("r2") _,
@@ -10785,7 +10785,7 @@ pub unsafe fn sd_ble_gattc_attr_info_discover(
     p_handle_range: *const ble_gattc_handle_range_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 159",
+    core::arch::asm!("svc 159",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_handle_range) => _,
         lateout("r2") _,
@@ -10828,7 +10828,7 @@ pub unsafe fn sd_ble_gattc_attr_info_discover(
 #[inline(always)]
 pub unsafe fn sd_ble_gattc_exchange_mtu_request(conn_handle: u16, client_rx_mtu: u16) -> u32 {
     let ret: u32;
-    asm!("svc 165",
+    core::arch::asm!("svc 165",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(client_rx_mtu) => _,
         lateout("r2") _,
@@ -12509,7 +12509,7 @@ pub unsafe fn sd_ble_gatts_service_add(
     p_handle: *mut u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 168",
+    core::arch::asm!("svc 168",
         inout("r0") to_asm(type_) => ret,
         inout("r1") to_asm(p_uuid) => _,
         inout("r2") to_asm(p_handle) => _,
@@ -12548,7 +12548,7 @@ pub unsafe fn sd_ble_gatts_include_add(
     p_include_handle: *mut u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 169",
+    core::arch::asm!("svc 169",
         inout("r0") to_asm(service_handle) => ret,
         inout("r1") to_asm(inc_srvc_handle) => _,
         inout("r2") to_asm(p_include_handle) => _,
@@ -12591,7 +12591,7 @@ pub unsafe fn sd_ble_gatts_characteristic_add(
     p_handles: *mut ble_gatts_char_handles_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 170",
+    core::arch::asm!("svc 170",
         inout("r0") to_asm(service_handle) => ret,
         inout("r1") to_asm(p_char_md) => _,
         inout("r2") to_asm(p_attr_char_value) => _,
@@ -12627,7 +12627,7 @@ pub unsafe fn sd_ble_gatts_descriptor_add(
     p_handle: *mut u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 171",
+    core::arch::asm!("svc 171",
         inout("r0") to_asm(char_handle) => ret,
         inout("r1") to_asm(p_attr) => _,
         inout("r2") to_asm(p_handle) => _,
@@ -12664,7 +12664,7 @@ pub unsafe fn sd_ble_gatts_value_set(
     p_value: *mut ble_gatts_value_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 172",
+    core::arch::asm!("svc 172",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(handle) => _,
         inout("r2") to_asm(p_value) => _,
@@ -12702,7 +12702,7 @@ pub unsafe fn sd_ble_gatts_value_get(
     p_value: *mut ble_gatts_value_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 173",
+    core::arch::asm!("svc 173",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(handle) => _,
         inout("r2") to_asm(p_value) => _,
@@ -12780,7 +12780,7 @@ pub unsafe fn sd_ble_gatts_hvx(
     p_hvx_params: *const ble_gatts_hvx_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 174",
+    core::arch::asm!("svc 174",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_hvx_params) => _,
         lateout("r2") _,
@@ -12830,7 +12830,7 @@ pub unsafe fn sd_ble_gatts_service_changed(
     end_handle: u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 175",
+    core::arch::asm!("svc 175",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(start_handle) => _,
         inout("r2") to_asm(end_handle) => _,
@@ -12876,7 +12876,7 @@ pub unsafe fn sd_ble_gatts_rw_authorize_reply(
     p_rw_authorize_reply_params: *const ble_gatts_rw_authorize_reply_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 176",
+    core::arch::asm!("svc 176",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_rw_authorize_reply_params) => _,
         lateout("r2") _,
@@ -12934,7 +12934,7 @@ pub unsafe fn sd_ble_gatts_sys_attr_set(
     flags: u32,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 177",
+    core::arch::asm!("svc 177",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_sys_attr_data) => _,
         inout("r2") to_asm(len) => _,
@@ -12981,7 +12981,7 @@ pub unsafe fn sd_ble_gatts_sys_attr_get(
     flags: u32,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 178",
+    core::arch::asm!("svc 178",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_sys_attr_data) => _,
         inout("r2") to_asm(p_len) => _,
@@ -13000,7 +13000,7 @@ pub unsafe fn sd_ble_gatts_sys_attr_get(
 #[inline(always)]
 pub unsafe fn sd_ble_gatts_initial_user_handle_get(p_handle: *mut u16) -> u32 {
     let ret: u32;
-    asm!("svc 179",
+    core::arch::asm!("svc 179",
         inout("r0") to_asm(p_handle) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -13027,7 +13027,7 @@ pub unsafe fn sd_ble_gatts_attr_get(
     p_md: *mut ble_gatts_attr_md_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 180",
+    core::arch::asm!("svc 180",
         inout("r0") to_asm(handle) => ret,
         inout("r1") to_asm(p_uuid) => _,
         inout("r2") to_asm(p_md) => _,
@@ -13067,7 +13067,7 @@ pub unsafe fn sd_ble_gatts_attr_get(
 #[inline(always)]
 pub unsafe fn sd_ble_gatts_exchange_mtu_reply(conn_handle: u16, server_rx_mtu: u16) -> u32 {
     let ret: u32;
-    asm!("svc 181",
+    core::arch::asm!("svc 181",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(server_rx_mtu) => _,
         lateout("r2") _,
@@ -14241,7 +14241,7 @@ fn bindgen_test_layout_ble_cfg_t() {
 #[inline(always)]
 pub unsafe fn sd_ble_enable(p_app_ram_base: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 96",
+    core::arch::asm!("svc 96",
         inout("r0") to_asm(p_app_ram_base) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -14287,7 +14287,7 @@ pub unsafe fn sd_ble_enable(p_app_ram_base: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_cfg_set(cfg_id: u32, p_cfg: *const ble_cfg_t, app_ram_base: u32) -> u32 {
     let ret: u32;
-    asm!("svc 105",
+    core::arch::asm!("svc 105",
         inout("r0") to_asm(cfg_id) => ret,
         inout("r1") to_asm(p_cfg) => _,
         inout("r2") to_asm(app_ram_base) => _,
@@ -14335,7 +14335,7 @@ pub unsafe fn sd_ble_cfg_set(cfg_id: u32, p_cfg: *const ble_cfg_t, app_ram_base:
 #[inline(always)]
 pub unsafe fn sd_ble_evt_get(p_dest: *mut u8, p_len: *mut u16) -> u32 {
     let ret: u32;
-    asm!("svc 97",
+    core::arch::asm!("svc 97",
         inout("r0") to_asm(p_dest) => ret,
         inout("r1") to_asm(p_len) => _,
         lateout("r2") _,
@@ -14373,7 +14373,7 @@ pub unsafe fn sd_ble_evt_get(p_dest: *mut u8, p_len: *mut u16) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_uuid_vs_add(p_vs_uuid: *const ble_uuid128_t, p_uuid_type: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 98",
+    core::arch::asm!("svc 98",
         inout("r0") to_asm(p_vs_uuid) => ret,
         inout("r1") to_asm(p_uuid_type) => _,
         lateout("r2") _,
@@ -14403,7 +14403,7 @@ pub unsafe fn sd_ble_uuid_vs_add(p_vs_uuid: *const ble_uuid128_t, p_uuid_type: *
 #[inline(always)]
 pub unsafe fn sd_ble_uuid_vs_remove(p_uuid_type: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 106",
+    core::arch::asm!("svc 106",
         inout("r0") to_asm(p_uuid_type) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -14437,7 +14437,7 @@ pub unsafe fn sd_ble_uuid_decode(
     p_uuid: *mut ble_uuid_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 99",
+    core::arch::asm!("svc 99",
         inout("r0") to_asm(uuid_le_len) => ret,
         inout("r1") to_asm(p_uuid_le) => _,
         inout("r2") to_asm(p_uuid) => _,
@@ -14465,7 +14465,7 @@ pub unsafe fn sd_ble_uuid_encode(
     p_uuid_le: *mut u8,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 100",
+    core::arch::asm!("svc 100",
         inout("r0") to_asm(p_uuid) => ret,
         inout("r1") to_asm(p_uuid_le_len) => _,
         inout("r2") to_asm(p_uuid_le) => _,
@@ -14487,7 +14487,7 @@ pub unsafe fn sd_ble_uuid_encode(
 #[inline(always)]
 pub unsafe fn sd_ble_version_get(p_version: *mut ble_version_t) -> u32 {
     let ret: u32;
-    asm!("svc 101",
+    core::arch::asm!("svc 101",
         inout("r0") to_asm(p_version) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -14522,7 +14522,7 @@ pub unsafe fn sd_ble_version_get(p_version: *mut ble_version_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_user_mem_reply(conn_handle: u16, p_block: *const ble_user_mem_block_t) -> u32 {
     let ret: u32;
-    asm!("svc 102",
+    core::arch::asm!("svc 102",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_block) => _,
         lateout("r2") _,
@@ -14548,7 +14548,7 @@ pub unsafe fn sd_ble_user_mem_reply(conn_handle: u16, p_block: *const ble_user_m
 #[inline(always)]
 pub unsafe fn sd_ble_opt_set(opt_id: u32, p_opt: *const ble_opt_t) -> u32 {
     let ret: u32;
-    asm!("svc 103",
+    core::arch::asm!("svc 103",
         inout("r0") to_asm(opt_id) => ret,
         inout("r1") to_asm(p_opt) => _,
         lateout("r2") _,
@@ -14576,7 +14576,7 @@ pub unsafe fn sd_ble_opt_set(opt_id: u32, p_opt: *const ble_opt_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_opt_get(opt_id: u32, p_opt: *mut ble_opt_t) -> u32 {
     let ret: u32;
-    asm!("svc 104",
+    core::arch::asm!("svc 104",
         inout("r0") to_asm(opt_id) => ret,
         inout("r1") to_asm(p_opt) => _,
         lateout("r2") _,

--- a/nrf-softdevice-s112/src/lib.rs
+++ b/nrf-softdevice-s112/src/lib.rs
@@ -3,7 +3,6 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_snake_case)]
 #![allow(dead_code)]
-#![feature(asm)]
 
 mod bindings;
 

--- a/nrf-softdevice-s113/src/bindings.rs
+++ b/nrf-softdevice-s113/src/bindings.rs
@@ -1659,7 +1659,7 @@ fn bindgen_test_layout_nrf_ecb_hal_data_block_t() {
 #[inline(always)]
 pub unsafe fn sd_mutex_new(p_mutex: *mut nrf_mutex_t) -> u32 {
     let ret: u32;
-    asm!("svc 44",
+    core::arch::asm!("svc 44",
         inout("r0") to_asm(p_mutex) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1678,7 +1678,7 @@ pub unsafe fn sd_mutex_new(p_mutex: *mut nrf_mutex_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_mutex_acquire(p_mutex: *mut nrf_mutex_t) -> u32 {
     let ret: u32;
-    asm!("svc 45",
+    core::arch::asm!("svc 45",
         inout("r0") to_asm(p_mutex) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1696,7 +1696,7 @@ pub unsafe fn sd_mutex_acquire(p_mutex: *mut nrf_mutex_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_mutex_release(p_mutex: *mut nrf_mutex_t) -> u32 {
     let ret: u32;
-    asm!("svc 46",
+    core::arch::asm!("svc 46",
         inout("r0") to_asm(p_mutex) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1714,7 +1714,7 @@ pub unsafe fn sd_mutex_release(p_mutex: *mut nrf_mutex_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_rand_application_pool_capacity_get(p_pool_capacity: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 47",
+    core::arch::asm!("svc 47",
         inout("r0") to_asm(p_pool_capacity) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1732,7 +1732,7 @@ pub unsafe fn sd_rand_application_pool_capacity_get(p_pool_capacity: *mut u8) ->
 #[inline(always)]
 pub unsafe fn sd_rand_application_bytes_available_get(p_bytes_available: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 48",
+    core::arch::asm!("svc 48",
         inout("r0") to_asm(p_bytes_available) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1752,7 +1752,7 @@ pub unsafe fn sd_rand_application_bytes_available_get(p_bytes_available: *mut u8
 #[inline(always)]
 pub unsafe fn sd_rand_application_vector_get(p_buff: *mut u8, length: u8) -> u32 {
     let ret: u32;
-    asm!("svc 49",
+    core::arch::asm!("svc 49",
         inout("r0") to_asm(p_buff) => ret,
         inout("r1") to_asm(length) => _,
         lateout("r2") _,
@@ -1770,7 +1770,7 @@ pub unsafe fn sd_rand_application_vector_get(p_buff: *mut u8, length: u8) -> u32
 #[inline(always)]
 pub unsafe fn sd_power_reset_reason_get(p_reset_reason: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 52",
+    core::arch::asm!("svc 52",
         inout("r0") to_asm(p_reset_reason) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1788,7 +1788,7 @@ pub unsafe fn sd_power_reset_reason_get(p_reset_reason: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_reset_reason_clr(reset_reason_clr_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 53",
+    core::arch::asm!("svc 53",
         inout("r0") to_asm(reset_reason_clr_msk) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1807,7 +1807,7 @@ pub unsafe fn sd_power_reset_reason_clr(reset_reason_clr_msk: u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_mode_set(power_mode: u8) -> u32 {
     let ret: u32;
-    asm!("svc 50",
+    core::arch::asm!("svc 50",
         inout("r0") to_asm(power_mode) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1823,7 +1823,7 @@ pub unsafe fn sd_power_mode_set(power_mode: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_system_off() -> u32 {
     let ret: u32;
-    asm!("svc 51",
+    core::arch::asm!("svc 51",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1844,7 +1844,7 @@ pub unsafe fn sd_power_system_off() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_pof_enable(pof_enable: u8) -> u32 {
     let ret: u32;
-    asm!("svc 54",
+    core::arch::asm!("svc 54",
         inout("r0") to_asm(pof_enable) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1867,7 +1867,7 @@ pub unsafe fn sd_power_pof_enable(pof_enable: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_usbpwrrdy_enable(usbpwrrdy_enable: u8) -> u32 {
     let ret: u32;
-    asm!("svc 77",
+    core::arch::asm!("svc 77",
         inout("r0") to_asm(usbpwrrdy_enable) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1890,7 +1890,7 @@ pub unsafe fn sd_power_usbpwrrdy_enable(usbpwrrdy_enable: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_usbdetected_enable(usbdetected_enable: u8) -> u32 {
     let ret: u32;
-    asm!("svc 78",
+    core::arch::asm!("svc 78",
         inout("r0") to_asm(usbdetected_enable) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1913,7 +1913,7 @@ pub unsafe fn sd_power_usbdetected_enable(usbdetected_enable: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_usbremoved_enable(usbremoved_enable: u8) -> u32 {
     let ret: u32;
-    asm!("svc 79",
+    core::arch::asm!("svc 79",
         inout("r0") to_asm(usbremoved_enable) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1933,7 +1933,7 @@ pub unsafe fn sd_power_usbremoved_enable(usbremoved_enable: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_usbregstatus_get(usbregstatus: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 80",
+    core::arch::asm!("svc 80",
         inout("r0") to_asm(usbregstatus) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1953,7 +1953,7 @@ pub unsafe fn sd_power_usbregstatus_get(usbregstatus: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_pof_threshold_set(threshold: u8) -> u32 {
     let ret: u32;
-    asm!("svc 55",
+    core::arch::asm!("svc 55",
         inout("r0") to_asm(threshold) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1972,7 +1972,7 @@ pub unsafe fn sd_power_pof_threshold_set(threshold: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_ram_power_set(index: u8, ram_powerset: u32) -> u32 {
     let ret: u32;
-    asm!("svc 57",
+    core::arch::asm!("svc 57",
         inout("r0") to_asm(index) => ret,
         inout("r1") to_asm(ram_powerset) => _,
         lateout("r2") _,
@@ -1991,7 +1991,7 @@ pub unsafe fn sd_power_ram_power_set(index: u8, ram_powerset: u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_ram_power_clr(index: u8, ram_powerclr: u32) -> u32 {
     let ret: u32;
-    asm!("svc 58",
+    core::arch::asm!("svc 58",
         inout("r0") to_asm(index) => ret,
         inout("r1") to_asm(ram_powerclr) => _,
         lateout("r2") _,
@@ -2010,7 +2010,7 @@ pub unsafe fn sd_power_ram_power_clr(index: u8, ram_powerclr: u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_ram_power_get(index: u8, p_ram_power: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 59",
+    core::arch::asm!("svc 59",
         inout("r0") to_asm(index) => ret,
         inout("r1") to_asm(p_ram_power) => _,
         lateout("r2") _,
@@ -2029,7 +2029,7 @@ pub unsafe fn sd_power_ram_power_get(index: u8, p_ram_power: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_gpregret_set(gpregret_id: u32, gpregret_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 60",
+    core::arch::asm!("svc 60",
         inout("r0") to_asm(gpregret_id) => ret,
         inout("r1") to_asm(gpregret_msk) => _,
         lateout("r2") _,
@@ -2048,7 +2048,7 @@ pub unsafe fn sd_power_gpregret_set(gpregret_id: u32, gpregret_msk: u32) -> u32 
 #[inline(always)]
 pub unsafe fn sd_power_gpregret_clr(gpregret_id: u32, gpregret_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 61",
+    core::arch::asm!("svc 61",
         inout("r0") to_asm(gpregret_id) => ret,
         inout("r1") to_asm(gpregret_msk) => _,
         lateout("r2") _,
@@ -2067,7 +2067,7 @@ pub unsafe fn sd_power_gpregret_clr(gpregret_id: u32, gpregret_msk: u32) -> u32 
 #[inline(always)]
 pub unsafe fn sd_power_gpregret_get(gpregret_id: u32, p_gpregret: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 62",
+    core::arch::asm!("svc 62",
         inout("r0") to_asm(gpregret_id) => ret,
         inout("r1") to_asm(p_gpregret) => _,
         lateout("r2") _,
@@ -2086,7 +2086,7 @@ pub unsafe fn sd_power_gpregret_get(gpregret_id: u32, p_gpregret: *mut u32) -> u
 #[inline(always)]
 pub unsafe fn sd_power_dcdc_mode_set(dcdc_mode: u8) -> u32 {
     let ret: u32;
-    asm!("svc 63",
+    core::arch::asm!("svc 63",
         inout("r0") to_asm(dcdc_mode) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2108,7 +2108,7 @@ pub unsafe fn sd_power_dcdc_mode_set(dcdc_mode: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_clock_hfclk_request() -> u32 {
     let ret: u32;
-    asm!("svc 66",
+    core::arch::asm!("svc 66",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2129,7 +2129,7 @@ pub unsafe fn sd_clock_hfclk_request() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_clock_hfclk_release() -> u32 {
     let ret: u32;
-    asm!("svc 67",
+    core::arch::asm!("svc 67",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2150,7 +2150,7 @@ pub unsafe fn sd_clock_hfclk_release() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_clock_hfclk_is_running(p_is_running: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 68",
+    core::arch::asm!("svc 68",
         inout("r0") to_asm(p_is_running) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2188,7 +2188,7 @@ pub unsafe fn sd_clock_hfclk_is_running(p_is_running: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_app_evt_wait() -> u32 {
     let ret: u32;
-    asm!("svc 65",
+    core::arch::asm!("svc 65",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2206,7 +2206,7 @@ pub unsafe fn sd_app_evt_wait() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_channel_enable_get(p_channel_enable: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 32",
+    core::arch::asm!("svc 32",
         inout("r0") to_asm(p_channel_enable) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2224,7 +2224,7 @@ pub unsafe fn sd_ppi_channel_enable_get(p_channel_enable: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_channel_enable_set(channel_enable_set_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 33",
+    core::arch::asm!("svc 33",
         inout("r0") to_asm(channel_enable_set_msk) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2242,7 +2242,7 @@ pub unsafe fn sd_ppi_channel_enable_set(channel_enable_set_msk: u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_channel_enable_clr(channel_enable_clr_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 34",
+    core::arch::asm!("svc 34",
         inout("r0") to_asm(channel_enable_clr_msk) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2267,7 +2267,7 @@ pub unsafe fn sd_ppi_channel_assign(
     task_endpoint: *const self::c_void,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 35",
+    core::arch::asm!("svc 35",
         inout("r0") to_asm(channel_num) => ret,
         inout("r1") to_asm(evt_endpoint) => _,
         inout("r2") to_asm(task_endpoint) => _,
@@ -2286,7 +2286,7 @@ pub unsafe fn sd_ppi_channel_assign(
 #[inline(always)]
 pub unsafe fn sd_ppi_group_task_enable(group_num: u8) -> u32 {
     let ret: u32;
-    asm!("svc 36",
+    core::arch::asm!("svc 36",
         inout("r0") to_asm(group_num) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2305,7 +2305,7 @@ pub unsafe fn sd_ppi_group_task_enable(group_num: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_group_task_disable(group_num: u8) -> u32 {
     let ret: u32;
-    asm!("svc 37",
+    core::arch::asm!("svc 37",
         inout("r0") to_asm(group_num) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2325,7 +2325,7 @@ pub unsafe fn sd_ppi_group_task_disable(group_num: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_group_assign(group_num: u8, channel_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 38",
+    core::arch::asm!("svc 38",
         inout("r0") to_asm(group_num) => ret,
         inout("r1") to_asm(channel_msk) => _,
         lateout("r2") _,
@@ -2345,7 +2345,7 @@ pub unsafe fn sd_ppi_group_assign(group_num: u8, channel_msk: u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_group_get(group_num: u8, p_channel_msk: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 39",
+    core::arch::asm!("svc 39",
         inout("r0") to_asm(group_num) => ret,
         inout("r1") to_asm(p_channel_msk) => _,
         lateout("r2") _,
@@ -2386,7 +2386,7 @@ pub unsafe fn sd_ppi_group_get(group_num: u8, p_channel_msk: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_radio_notification_cfg_set(type_: u8, distance: u8) -> u32 {
     let ret: u32;
-    asm!("svc 69",
+    core::arch::asm!("svc 69",
         inout("r0") to_asm(type_) => ret,
         inout("r1") to_asm(distance) => _,
         lateout("r2") _,
@@ -2412,7 +2412,7 @@ pub unsafe fn sd_radio_notification_cfg_set(type_: u8, distance: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ecb_block_encrypt(p_ecb_data: *mut nrf_ecb_hal_data_t) -> u32 {
     let ret: u32;
-    asm!("svc 70",
+    core::arch::asm!("svc 70",
         inout("r0") to_asm(p_ecb_data) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2442,7 +2442,7 @@ pub unsafe fn sd_ecb_blocks_encrypt(
     p_data_blocks: *mut nrf_ecb_hal_data_block_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 71",
+    core::arch::asm!("svc 71",
         inout("r0") to_asm(block_count) => ret,
         inout("r1") to_asm(p_data_blocks) => _,
         lateout("r2") _,
@@ -2463,7 +2463,7 @@ pub unsafe fn sd_ecb_blocks_encrypt(
 #[inline(always)]
 pub unsafe fn sd_evt_get(p_evt_id: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 75",
+    core::arch::asm!("svc 75",
         inout("r0") to_asm(p_evt_id) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2484,7 +2484,7 @@ pub unsafe fn sd_evt_get(p_evt_id: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_temp_get(p_temp: *mut i32) -> u32 {
     let ret: u32;
-    asm!("svc 76",
+    core::arch::asm!("svc 76",
         inout("r0") to_asm(p_temp) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2531,7 +2531,7 @@ pub unsafe fn sd_temp_get(p_temp: *mut i32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_flash_write(p_dst: *mut u32, p_src: *const u32, size: u32) -> u32 {
     let ret: u32;
-    asm!("svc 41",
+    core::arch::asm!("svc 41",
         inout("r0") to_asm(p_dst) => ret,
         inout("r1") to_asm(p_src) => _,
         inout("r2") to_asm(size) => _,
@@ -2572,7 +2572,7 @@ pub unsafe fn sd_flash_write(p_dst: *mut u32, p_src: *const u32, size: u32) -> u
 #[inline(always)]
 pub unsafe fn sd_flash_page_erase(page_number: u32) -> u32 {
     let ret: u32;
-    asm!("svc 40",
+    core::arch::asm!("svc 40",
         inout("r0") to_asm(page_number) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2609,7 +2609,7 @@ pub unsafe fn sd_flash_protect(
     block_cfg3: u32,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 42",
+    core::arch::asm!("svc 42",
         inout("r0") to_asm(block_cfg0) => ret,
         inout("r1") to_asm(block_cfg1) => _,
         inout("r2") to_asm(block_cfg2) => _,
@@ -2641,7 +2641,7 @@ pub unsafe fn sd_flash_protect(
 #[inline(always)]
 pub unsafe fn sd_radio_session_open(p_radio_signal_callback: nrf_radio_signal_callback_t) -> u32 {
     let ret: u32;
-    asm!("svc 72",
+    core::arch::asm!("svc 72",
         inout("r0") to_asm(p_radio_signal_callback) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2664,7 +2664,7 @@ pub unsafe fn sd_radio_session_open(p_radio_signal_callback: nrf_radio_signal_ca
 #[inline(always)]
 pub unsafe fn sd_radio_session_close() -> u32 {
     let ret: u32;
-    asm!("svc 73",
+    core::arch::asm!("svc 73",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2711,7 +2711,7 @@ pub unsafe fn sd_radio_session_close() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_radio_request(p_request: *const nrf_radio_request_t) -> u32 {
     let ret: u32;
-    asm!("svc 74",
+    core::arch::asm!("svc 74",
         inout("r0") to_asm(p_request) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2742,7 +2742,7 @@ pub unsafe fn sd_radio_request(p_request: *const nrf_radio_request_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_protected_register_write(p_register: *mut u32, value: u32) -> u32 {
     let ret: u32;
-    asm!("svc 43",
+    core::arch::asm!("svc 43",
         inout("r0") to_asm(p_register) => ret,
         inout("r1") to_asm(value) => _,
         lateout("r2") _,
@@ -2912,7 +2912,7 @@ pub unsafe fn sd_softdevice_enable(
     fault_handler: nrf_fault_handler_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 16",
+    core::arch::asm!("svc 16",
         inout("r0") to_asm(p_clock_lf_cfg) => ret,
         inout("r1") to_asm(fault_handler) => _,
         lateout("r2") _,
@@ -2937,7 +2937,7 @@ pub unsafe fn sd_softdevice_enable(
 #[inline(always)]
 pub unsafe fn sd_softdevice_disable() -> u32 {
     let ret: u32;
-    asm!("svc 17",
+    core::arch::asm!("svc 17",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2955,7 +2955,7 @@ pub unsafe fn sd_softdevice_disable() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_softdevice_is_enabled(p_softdevice_enabled: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 18",
+    core::arch::asm!("svc 18",
         inout("r0") to_asm(p_softdevice_enabled) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2975,7 +2975,7 @@ pub unsafe fn sd_softdevice_is_enabled(p_softdevice_enabled: *mut u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_softdevice_vector_table_base_set(address: u32) -> u32 {
     let ret: u32;
-    asm!("svc 19",
+    core::arch::asm!("svc 19",
         inout("r0") to_asm(address) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -3803,7 +3803,7 @@ fn bindgen_test_layout_sd_mbr_command_t() {
 #[inline(always)]
 pub unsafe fn sd_mbr_command(param: *mut sd_mbr_command_t) -> u32 {
     let ret: u32;
-    asm!("svc 24",
+    core::arch::asm!("svc 24",
         inout("r0") to_asm(param) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -8127,7 +8127,7 @@ fn bindgen_test_layout_ble_gap_conn_event_trigger_t() {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_addr_set(p_addr: *const ble_gap_addr_t) -> u32 {
     let ret: u32;
-    asm!("svc 108",
+    core::arch::asm!("svc 108",
         inout("r0") to_asm(p_addr) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -8149,7 +8149,7 @@ pub unsafe fn sd_ble_gap_addr_set(p_addr: *const ble_gap_addr_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_addr_get(p_addr: *mut ble_gap_addr_t) -> u32 {
     let ret: u32;
-    asm!("svc 109",
+    core::arch::asm!("svc 109",
         inout("r0") to_asm(p_addr) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -8177,7 +8177,7 @@ pub unsafe fn sd_ble_gap_addr_get(p_addr: *mut ble_gap_addr_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_adv_addr_get(adv_handle: u8, p_addr: *mut ble_gap_addr_t) -> u32 {
     let ret: u32;
-    asm!("svc 147",
+    core::arch::asm!("svc 147",
         inout("r0") to_asm(adv_handle) => ret,
         inout("r1") to_asm(p_addr) => _,
         lateout("r2") _,
@@ -8207,7 +8207,7 @@ pub unsafe fn sd_ble_gap_adv_addr_get(adv_handle: u8, p_addr: *mut ble_gap_addr_
 #[inline(always)]
 pub unsafe fn sd_ble_gap_whitelist_set(pp_wl_addrs: *const *const ble_gap_addr_t, len: u8) -> u32 {
     let ret: u32;
-    asm!("svc 110",
+    core::arch::asm!("svc 110",
         inout("r0") to_asm(pp_wl_addrs) => ret,
         inout("r1") to_asm(len) => _,
         lateout("r2") _,
@@ -8248,7 +8248,7 @@ pub unsafe fn sd_ble_gap_device_identities_set(
     len: u8,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 111",
+    core::arch::asm!("svc 111",
         inout("r0") to_asm(pp_id_keys) => ret,
         inout("r1") to_asm(pp_local_irks) => _,
         inout("r2") to_asm(len) => _,
@@ -8279,7 +8279,7 @@ pub unsafe fn sd_ble_gap_device_identities_set(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_privacy_set(p_privacy_params: *const ble_gap_privacy_params_t) -> u32 {
     let ret: u32;
-    asm!("svc 112",
+    core::arch::asm!("svc 112",
         inout("r0") to_asm(p_privacy_params) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -8302,7 +8302,7 @@ pub unsafe fn sd_ble_gap_privacy_set(p_privacy_params: *const ble_gap_privacy_pa
 #[inline(always)]
 pub unsafe fn sd_ble_gap_privacy_get(p_privacy_params: *mut ble_gap_privacy_params_t) -> u32 {
     let ret: u32;
-    asm!("svc 113",
+    core::arch::asm!("svc 113",
         inout("r0") to_asm(p_privacy_params) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -8361,7 +8361,7 @@ pub unsafe fn sd_ble_gap_adv_set_configure(
     p_adv_params: *const ble_gap_adv_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 114",
+    core::arch::asm!("svc 114",
         inout("r0") to_asm(p_adv_handle) => ret,
         inout("r1") to_asm(p_adv_data) => _,
         inout("r2") to_asm(p_adv_params) => _,
@@ -8416,7 +8416,7 @@ pub unsafe fn sd_ble_gap_adv_set_configure(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_adv_start(adv_handle: u8, conn_cfg_tag: u8) -> u32 {
     let ret: u32;
-    asm!("svc 115",
+    core::arch::asm!("svc 115",
         inout("r0") to_asm(adv_handle) => ret,
         inout("r1") to_asm(conn_cfg_tag) => _,
         lateout("r2") _,
@@ -8440,7 +8440,7 @@ pub unsafe fn sd_ble_gap_adv_start(adv_handle: u8, conn_cfg_tag: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_adv_stop(adv_handle: u8) -> u32 {
     let ret: u32;
-    asm!("svc 116",
+    core::arch::asm!("svc 116",
         inout("r0") to_asm(adv_handle) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -8481,7 +8481,7 @@ pub unsafe fn sd_ble_gap_conn_param_update(
     p_conn_params: *const ble_gap_conn_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 117",
+    core::arch::asm!("svc 117",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_conn_params) => _,
         lateout("r2") _,
@@ -8514,7 +8514,7 @@ pub unsafe fn sd_ble_gap_conn_param_update(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_disconnect(conn_handle: u16, hci_status_code: u8) -> u32 {
     let ret: u32;
-    asm!("svc 118",
+    core::arch::asm!("svc 118",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(hci_status_code) => _,
         lateout("r2") _,
@@ -8548,7 +8548,7 @@ pub unsafe fn sd_ble_gap_disconnect(conn_handle: u16, hci_status_code: u8) -> u3
 #[inline(always)]
 pub unsafe fn sd_ble_gap_tx_power_set(role: u8, handle: u16, tx_power: i8) -> u32 {
     let ret: u32;
-    asm!("svc 119",
+    core::arch::asm!("svc 119",
         inout("r0") to_asm(role) => ret,
         inout("r1") to_asm(handle) => _,
         inout("r2") to_asm(tx_power) => _,
@@ -8567,7 +8567,7 @@ pub unsafe fn sd_ble_gap_tx_power_set(role: u8, handle: u16, tx_power: i8) -> u3
 #[inline(always)]
 pub unsafe fn sd_ble_gap_appearance_set(appearance: u16) -> u32 {
     let ret: u32;
-    asm!("svc 120",
+    core::arch::asm!("svc 120",
         inout("r0") to_asm(appearance) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -8586,7 +8586,7 @@ pub unsafe fn sd_ble_gap_appearance_set(appearance: u16) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_appearance_get(p_appearance: *mut u16) -> u32 {
     let ret: u32;
-    asm!("svc 121",
+    core::arch::asm!("svc 121",
         inout("r0") to_asm(p_appearance) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -8608,7 +8608,7 @@ pub unsafe fn sd_ble_gap_appearance_get(p_appearance: *mut u16) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_ppcp_set(p_conn_params: *const ble_gap_conn_params_t) -> u32 {
     let ret: u32;
-    asm!("svc 122",
+    core::arch::asm!("svc 122",
         inout("r0") to_asm(p_conn_params) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -8629,7 +8629,7 @@ pub unsafe fn sd_ble_gap_ppcp_set(p_conn_params: *const ble_gap_conn_params_t) -
 #[inline(always)]
 pub unsafe fn sd_ble_gap_ppcp_get(p_conn_params: *mut ble_gap_conn_params_t) -> u32 {
     let ret: u32;
-    asm!("svc 123",
+    core::arch::asm!("svc 123",
         inout("r0") to_asm(p_conn_params) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -8660,7 +8660,7 @@ pub unsafe fn sd_ble_gap_device_name_set(
     len: u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 124",
+    core::arch::asm!("svc 124",
         inout("r0") to_asm(p_write_perm) => ret,
         inout("r1") to_asm(p_dev_name) => _,
         inout("r2") to_asm(len) => _,
@@ -8686,7 +8686,7 @@ pub unsafe fn sd_ble_gap_device_name_set(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_device_name_get(p_dev_name: *mut u8, p_len: *mut u16) -> u32 {
     let ret: u32;
-    asm!("svc 125",
+    core::arch::asm!("svc 125",
         inout("r0") to_asm(p_dev_name) => ret,
         inout("r1") to_asm(p_len) => _,
         lateout("r2") _,
@@ -8735,7 +8735,7 @@ pub unsafe fn sd_ble_gap_authenticate(
     p_sec_params: *const ble_gap_sec_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 126",
+    core::arch::asm!("svc 126",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_sec_params) => _,
         lateout("r2") _,
@@ -8798,7 +8798,7 @@ pub unsafe fn sd_ble_gap_sec_params_reply(
     p_sec_keyset: *const ble_gap_sec_keyset_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 127",
+    core::arch::asm!("svc 127",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(sec_status) => _,
         inout("r2") to_asm(p_sec_params) => _,
@@ -8838,7 +8838,7 @@ pub unsafe fn sd_ble_gap_sec_params_reply(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_auth_key_reply(conn_handle: u16, key_type: u8, p_key: *const u8) -> u32 {
     let ret: u32;
-    asm!("svc 128",
+    core::arch::asm!("svc 128",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(key_type) => _,
         inout("r2") to_asm(p_key) => _,
@@ -8881,7 +8881,7 @@ pub unsafe fn sd_ble_gap_lesc_dhkey_reply(
     p_dhkey: *const ble_gap_lesc_dhkey_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 129",
+    core::arch::asm!("svc 129",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_dhkey) => _,
         lateout("r2") _,
@@ -8911,7 +8911,7 @@ pub unsafe fn sd_ble_gap_lesc_dhkey_reply(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_keypress_notify(conn_handle: u16, kp_not: u8) -> u32 {
     let ret: u32;
-    asm!("svc 130",
+    core::arch::asm!("svc 130",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(kp_not) => _,
         lateout("r2") _,
@@ -8944,7 +8944,7 @@ pub unsafe fn sd_ble_gap_lesc_oob_data_get(
     p_oobd_own: *mut ble_gap_lesc_oob_data_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 131",
+    core::arch::asm!("svc 131",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_pk_own) => _,
         inout("r2") to_asm(p_oobd_own) => _,
@@ -8988,7 +8988,7 @@ pub unsafe fn sd_ble_gap_lesc_oob_data_set(
     p_oobd_peer: *const ble_gap_lesc_oob_data_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 132",
+    core::arch::asm!("svc 132",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_oobd_own) => _,
         inout("r2") to_asm(p_oobd_peer) => _,
@@ -9028,7 +9028,7 @@ pub unsafe fn sd_ble_gap_sec_info_reply(
     p_sign_info: *const ble_gap_sign_info_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 134",
+    core::arch::asm!("svc 134",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_enc_info) => _,
         inout("r2") to_asm(p_id_info) => _,
@@ -9052,7 +9052,7 @@ pub unsafe fn sd_ble_gap_conn_sec_get(
     p_conn_sec: *mut ble_gap_conn_sec_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 135",
+    core::arch::asm!("svc 135",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_conn_sec) => _,
         lateout("r2") _,
@@ -9087,7 +9087,7 @@ pub unsafe fn sd_ble_gap_conn_sec_get(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_rssi_start(conn_handle: u16, threshold_dbm: u8, skip_count: u8) -> u32 {
     let ret: u32;
-    asm!("svc 136",
+    core::arch::asm!("svc 136",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(threshold_dbm) => _,
         inout("r2") to_asm(skip_count) => _,
@@ -9115,7 +9115,7 @@ pub unsafe fn sd_ble_gap_rssi_start(conn_handle: u16, threshold_dbm: u8, skip_co
 #[inline(always)]
 pub unsafe fn sd_ble_gap_rssi_stop(conn_handle: u16) -> u32 {
     let ret: u32;
-    asm!("svc 137",
+    core::arch::asm!("svc 137",
         inout("r0") to_asm(conn_handle) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -9145,7 +9145,7 @@ pub unsafe fn sd_ble_gap_rssi_stop(conn_handle: u16) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_rssi_get(conn_handle: u16, p_rssi: *mut i8, p_ch_index: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 142",
+    core::arch::asm!("svc 142",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_rssi) => _,
         inout("r2") to_asm(p_ch_index) => _,
@@ -9205,7 +9205,7 @@ pub unsafe fn sd_ble_gap_rssi_get(conn_handle: u16, p_rssi: *mut i8, p_ch_index:
 #[inline(always)]
 pub unsafe fn sd_ble_gap_phy_update(conn_handle: u16, p_gap_phys: *const ble_gap_phys_t) -> u32 {
     let ret: u32;
-    asm!("svc 143",
+    core::arch::asm!("svc 143",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_gap_phys) => _,
         lateout("r2") _,
@@ -9253,7 +9253,7 @@ pub unsafe fn sd_ble_gap_data_length_update(
     p_dl_limitation: *mut ble_gap_data_length_limitation_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 144",
+    core::arch::asm!("svc 144",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_dl_params) => _,
         inout("r2") to_asm(p_dl_limitation) => _,
@@ -9286,7 +9286,7 @@ pub unsafe fn sd_ble_gap_data_length_update(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_next_conn_evt_counter_get(conn_handle: u16, p_counter: *mut u16) -> u32 {
     let ret: u32;
-    asm!("svc 148",
+    core::arch::asm!("svc 148",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_counter) => _,
         lateout("r2") _,
@@ -9320,7 +9320,7 @@ pub unsafe fn sd_ble_gap_conn_evt_trigger_start(
     p_params: *const ble_gap_conn_event_trigger_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 149",
+    core::arch::asm!("svc 149",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_params) => _,
         lateout("r2") _,
@@ -9340,7 +9340,7 @@ pub unsafe fn sd_ble_gap_conn_evt_trigger_start(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_conn_evt_trigger_stop(conn_handle: u16) -> u32 {
     let ret: u32;
-    asm!("svc 150",
+    core::arch::asm!("svc 150",
         inout("r0") to_asm(conn_handle) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -10201,7 +10201,7 @@ pub unsafe fn sd_ble_l2cap_ch_setup(
     p_params: *const ble_l2cap_ch_setup_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 184",
+    core::arch::asm!("svc 184",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_local_cid) => _,
         inout("r2") to_asm(p_params) => _,
@@ -10234,7 +10234,7 @@ pub unsafe fn sd_ble_l2cap_ch_setup(
 #[inline(always)]
 pub unsafe fn sd_ble_l2cap_ch_release(conn_handle: u16, local_cid: u16) -> u32 {
     let ret: u32;
-    asm!("svc 185",
+    core::arch::asm!("svc 185",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(local_cid) => _,
         lateout("r2") _,
@@ -10282,7 +10282,7 @@ pub unsafe fn sd_ble_l2cap_ch_rx(
     p_sdu_buf: *const ble_data_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 186",
+    core::arch::asm!("svc 186",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(local_cid) => _,
         inout("r2") to_asm(p_sdu_buf) => _,
@@ -10341,7 +10341,7 @@ pub unsafe fn sd_ble_l2cap_ch_tx(
     p_sdu_buf: *const ble_data_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 187",
+    core::arch::asm!("svc 187",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(local_cid) => _,
         inout("r2") to_asm(p_sdu_buf) => _,
@@ -10400,7 +10400,7 @@ pub unsafe fn sd_ble_l2cap_ch_flow_control(
     p_credits: *mut u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 188",
+    core::arch::asm!("svc 188",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(local_cid) => _,
         inout("r2") to_asm(credits) => _,
@@ -12065,7 +12065,7 @@ pub unsafe fn sd_ble_gattc_primary_services_discover(
     p_srvc_uuid: *const ble_uuid_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 155",
+    core::arch::asm!("svc 155",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(start_handle) => _,
         inout("r2") to_asm(p_srvc_uuid) => _,
@@ -12104,7 +12104,7 @@ pub unsafe fn sd_ble_gattc_relationships_discover(
     p_handle_range: *const ble_gattc_handle_range_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 156",
+    core::arch::asm!("svc 156",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_handle_range) => _,
         lateout("r2") _,
@@ -12145,7 +12145,7 @@ pub unsafe fn sd_ble_gattc_characteristics_discover(
     p_handle_range: *const ble_gattc_handle_range_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 157",
+    core::arch::asm!("svc 157",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_handle_range) => _,
         lateout("r2") _,
@@ -12183,7 +12183,7 @@ pub unsafe fn sd_ble_gattc_descriptors_discover(
     p_handle_range: *const ble_gattc_handle_range_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 158",
+    core::arch::asm!("svc 158",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_handle_range) => _,
         lateout("r2") _,
@@ -12223,7 +12223,7 @@ pub unsafe fn sd_ble_gattc_char_value_by_uuid_read(
     p_handle_range: *const ble_gattc_handle_range_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 160",
+    core::arch::asm!("svc 160",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_uuid) => _,
         inout("r2") to_asm(p_handle_range) => _,
@@ -12259,7 +12259,7 @@ pub unsafe fn sd_ble_gattc_char_value_by_uuid_read(
 #[inline(always)]
 pub unsafe fn sd_ble_gattc_read(conn_handle: u16, handle: u16, offset: u16) -> u32 {
     let ret: u32;
-    asm!("svc 161",
+    core::arch::asm!("svc 161",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(handle) => _,
         inout("r2") to_asm(offset) => _,
@@ -12298,7 +12298,7 @@ pub unsafe fn sd_ble_gattc_char_values_read(
     handle_count: u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 162",
+    core::arch::asm!("svc 162",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_handles) => _,
         inout("r2") to_asm(handle_count) => _,
@@ -12357,7 +12357,7 @@ pub unsafe fn sd_ble_gattc_write(
     p_write_params: *const ble_gattc_write_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 163",
+    core::arch::asm!("svc 163",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_write_params) => _,
         lateout("r2") _,
@@ -12384,7 +12384,7 @@ pub unsafe fn sd_ble_gattc_write(
 #[inline(always)]
 pub unsafe fn sd_ble_gattc_hv_confirm(conn_handle: u16, handle: u16) -> u32 {
     let ret: u32;
-    asm!("svc 164",
+    core::arch::asm!("svc 164",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(handle) => _,
         lateout("r2") _,
@@ -12415,7 +12415,7 @@ pub unsafe fn sd_ble_gattc_attr_info_discover(
     p_handle_range: *const ble_gattc_handle_range_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 159",
+    core::arch::asm!("svc 159",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_handle_range) => _,
         lateout("r2") _,
@@ -12458,7 +12458,7 @@ pub unsafe fn sd_ble_gattc_attr_info_discover(
 #[inline(always)]
 pub unsafe fn sd_ble_gattc_exchange_mtu_request(conn_handle: u16, client_rx_mtu: u16) -> u32 {
     let ret: u32;
-    asm!("svc 165",
+    core::arch::asm!("svc 165",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(client_rx_mtu) => _,
         lateout("r2") _,
@@ -14139,7 +14139,7 @@ pub unsafe fn sd_ble_gatts_service_add(
     p_handle: *mut u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 168",
+    core::arch::asm!("svc 168",
         inout("r0") to_asm(type_) => ret,
         inout("r1") to_asm(p_uuid) => _,
         inout("r2") to_asm(p_handle) => _,
@@ -14178,7 +14178,7 @@ pub unsafe fn sd_ble_gatts_include_add(
     p_include_handle: *mut u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 169",
+    core::arch::asm!("svc 169",
         inout("r0") to_asm(service_handle) => ret,
         inout("r1") to_asm(inc_srvc_handle) => _,
         inout("r2") to_asm(p_include_handle) => _,
@@ -14221,7 +14221,7 @@ pub unsafe fn sd_ble_gatts_characteristic_add(
     p_handles: *mut ble_gatts_char_handles_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 170",
+    core::arch::asm!("svc 170",
         inout("r0") to_asm(service_handle) => ret,
         inout("r1") to_asm(p_char_md) => _,
         inout("r2") to_asm(p_attr_char_value) => _,
@@ -14257,7 +14257,7 @@ pub unsafe fn sd_ble_gatts_descriptor_add(
     p_handle: *mut u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 171",
+    core::arch::asm!("svc 171",
         inout("r0") to_asm(char_handle) => ret,
         inout("r1") to_asm(p_attr) => _,
         inout("r2") to_asm(p_handle) => _,
@@ -14294,7 +14294,7 @@ pub unsafe fn sd_ble_gatts_value_set(
     p_value: *mut ble_gatts_value_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 172",
+    core::arch::asm!("svc 172",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(handle) => _,
         inout("r2") to_asm(p_value) => _,
@@ -14332,7 +14332,7 @@ pub unsafe fn sd_ble_gatts_value_get(
     p_value: *mut ble_gatts_value_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 173",
+    core::arch::asm!("svc 173",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(handle) => _,
         inout("r2") to_asm(p_value) => _,
@@ -14410,7 +14410,7 @@ pub unsafe fn sd_ble_gatts_hvx(
     p_hvx_params: *const ble_gatts_hvx_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 174",
+    core::arch::asm!("svc 174",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_hvx_params) => _,
         lateout("r2") _,
@@ -14460,7 +14460,7 @@ pub unsafe fn sd_ble_gatts_service_changed(
     end_handle: u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 175",
+    core::arch::asm!("svc 175",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(start_handle) => _,
         inout("r2") to_asm(end_handle) => _,
@@ -14506,7 +14506,7 @@ pub unsafe fn sd_ble_gatts_rw_authorize_reply(
     p_rw_authorize_reply_params: *const ble_gatts_rw_authorize_reply_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 176",
+    core::arch::asm!("svc 176",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_rw_authorize_reply_params) => _,
         lateout("r2") _,
@@ -14564,7 +14564,7 @@ pub unsafe fn sd_ble_gatts_sys_attr_set(
     flags: u32,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 177",
+    core::arch::asm!("svc 177",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_sys_attr_data) => _,
         inout("r2") to_asm(len) => _,
@@ -14611,7 +14611,7 @@ pub unsafe fn sd_ble_gatts_sys_attr_get(
     flags: u32,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 178",
+    core::arch::asm!("svc 178",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_sys_attr_data) => _,
         inout("r2") to_asm(p_len) => _,
@@ -14630,7 +14630,7 @@ pub unsafe fn sd_ble_gatts_sys_attr_get(
 #[inline(always)]
 pub unsafe fn sd_ble_gatts_initial_user_handle_get(p_handle: *mut u16) -> u32 {
     let ret: u32;
-    asm!("svc 179",
+    core::arch::asm!("svc 179",
         inout("r0") to_asm(p_handle) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -14657,7 +14657,7 @@ pub unsafe fn sd_ble_gatts_attr_get(
     p_md: *mut ble_gatts_attr_md_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 180",
+    core::arch::asm!("svc 180",
         inout("r0") to_asm(handle) => ret,
         inout("r1") to_asm(p_uuid) => _,
         inout("r2") to_asm(p_md) => _,
@@ -14697,7 +14697,7 @@ pub unsafe fn sd_ble_gatts_attr_get(
 #[inline(always)]
 pub unsafe fn sd_ble_gatts_exchange_mtu_reply(conn_handle: u16, server_rx_mtu: u16) -> u32 {
     let ret: u32;
-    asm!("svc 181",
+    core::arch::asm!("svc 181",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(server_rx_mtu) => _,
         lateout("r2") _,
@@ -15902,7 +15902,7 @@ fn bindgen_test_layout_ble_cfg_t() {
 #[inline(always)]
 pub unsafe fn sd_ble_enable(p_app_ram_base: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 96",
+    core::arch::asm!("svc 96",
         inout("r0") to_asm(p_app_ram_base) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -15948,7 +15948,7 @@ pub unsafe fn sd_ble_enable(p_app_ram_base: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_cfg_set(cfg_id: u32, p_cfg: *const ble_cfg_t, app_ram_base: u32) -> u32 {
     let ret: u32;
-    asm!("svc 105",
+    core::arch::asm!("svc 105",
         inout("r0") to_asm(cfg_id) => ret,
         inout("r1") to_asm(p_cfg) => _,
         inout("r2") to_asm(app_ram_base) => _,
@@ -15996,7 +15996,7 @@ pub unsafe fn sd_ble_cfg_set(cfg_id: u32, p_cfg: *const ble_cfg_t, app_ram_base:
 #[inline(always)]
 pub unsafe fn sd_ble_evt_get(p_dest: *mut u8, p_len: *mut u16) -> u32 {
     let ret: u32;
-    asm!("svc 97",
+    core::arch::asm!("svc 97",
         inout("r0") to_asm(p_dest) => ret,
         inout("r1") to_asm(p_len) => _,
         lateout("r2") _,
@@ -16034,7 +16034,7 @@ pub unsafe fn sd_ble_evt_get(p_dest: *mut u8, p_len: *mut u16) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_uuid_vs_add(p_vs_uuid: *const ble_uuid128_t, p_uuid_type: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 98",
+    core::arch::asm!("svc 98",
         inout("r0") to_asm(p_vs_uuid) => ret,
         inout("r1") to_asm(p_uuid_type) => _,
         lateout("r2") _,
@@ -16064,7 +16064,7 @@ pub unsafe fn sd_ble_uuid_vs_add(p_vs_uuid: *const ble_uuid128_t, p_uuid_type: *
 #[inline(always)]
 pub unsafe fn sd_ble_uuid_vs_remove(p_uuid_type: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 106",
+    core::arch::asm!("svc 106",
         inout("r0") to_asm(p_uuid_type) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -16098,7 +16098,7 @@ pub unsafe fn sd_ble_uuid_decode(
     p_uuid: *mut ble_uuid_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 99",
+    core::arch::asm!("svc 99",
         inout("r0") to_asm(uuid_le_len) => ret,
         inout("r1") to_asm(p_uuid_le) => _,
         inout("r2") to_asm(p_uuid) => _,
@@ -16126,7 +16126,7 @@ pub unsafe fn sd_ble_uuid_encode(
     p_uuid_le: *mut u8,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 100",
+    core::arch::asm!("svc 100",
         inout("r0") to_asm(p_uuid) => ret,
         inout("r1") to_asm(p_uuid_le_len) => _,
         inout("r2") to_asm(p_uuid_le) => _,
@@ -16148,7 +16148,7 @@ pub unsafe fn sd_ble_uuid_encode(
 #[inline(always)]
 pub unsafe fn sd_ble_version_get(p_version: *mut ble_version_t) -> u32 {
     let ret: u32;
-    asm!("svc 101",
+    core::arch::asm!("svc 101",
         inout("r0") to_asm(p_version) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -16183,7 +16183,7 @@ pub unsafe fn sd_ble_version_get(p_version: *mut ble_version_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_user_mem_reply(conn_handle: u16, p_block: *const ble_user_mem_block_t) -> u32 {
     let ret: u32;
-    asm!("svc 102",
+    core::arch::asm!("svc 102",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_block) => _,
         lateout("r2") _,
@@ -16209,7 +16209,7 @@ pub unsafe fn sd_ble_user_mem_reply(conn_handle: u16, p_block: *const ble_user_m
 #[inline(always)]
 pub unsafe fn sd_ble_opt_set(opt_id: u32, p_opt: *const ble_opt_t) -> u32 {
     let ret: u32;
-    asm!("svc 103",
+    core::arch::asm!("svc 103",
         inout("r0") to_asm(opt_id) => ret,
         inout("r1") to_asm(p_opt) => _,
         lateout("r2") _,
@@ -16237,7 +16237,7 @@ pub unsafe fn sd_ble_opt_set(opt_id: u32, p_opt: *const ble_opt_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_opt_get(opt_id: u32, p_opt: *mut ble_opt_t) -> u32 {
     let ret: u32;
-    asm!("svc 104",
+    core::arch::asm!("svc 104",
         inout("r0") to_asm(opt_id) => ret,
         inout("r1") to_asm(p_opt) => _,
         lateout("r2") _,

--- a/nrf-softdevice-s113/src/lib.rs
+++ b/nrf-softdevice-s113/src/lib.rs
@@ -3,7 +3,6 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_snake_case)]
 #![allow(dead_code)]
-#![feature(asm)]
 
 mod bindings;
 

--- a/nrf-softdevice-s122/src/bindings.rs
+++ b/nrf-softdevice-s122/src/bindings.rs
@@ -1637,7 +1637,7 @@ fn bindgen_test_layout_nrf_ecb_hal_data_block_t() {
 #[inline(always)]
 pub unsafe fn sd_mutex_new(p_mutex: *mut nrf_mutex_t) -> u32 {
     let ret: u32;
-    asm!("svc 44",
+    core::arch::asm!("svc 44",
         inout("r0") to_asm(p_mutex) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1656,7 +1656,7 @@ pub unsafe fn sd_mutex_new(p_mutex: *mut nrf_mutex_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_mutex_acquire(p_mutex: *mut nrf_mutex_t) -> u32 {
     let ret: u32;
-    asm!("svc 45",
+    core::arch::asm!("svc 45",
         inout("r0") to_asm(p_mutex) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1674,7 +1674,7 @@ pub unsafe fn sd_mutex_acquire(p_mutex: *mut nrf_mutex_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_mutex_release(p_mutex: *mut nrf_mutex_t) -> u32 {
     let ret: u32;
-    asm!("svc 46",
+    core::arch::asm!("svc 46",
         inout("r0") to_asm(p_mutex) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1692,7 +1692,7 @@ pub unsafe fn sd_mutex_release(p_mutex: *mut nrf_mutex_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_rand_application_pool_capacity_get(p_pool_capacity: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 47",
+    core::arch::asm!("svc 47",
         inout("r0") to_asm(p_pool_capacity) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1710,7 +1710,7 @@ pub unsafe fn sd_rand_application_pool_capacity_get(p_pool_capacity: *mut u8) ->
 #[inline(always)]
 pub unsafe fn sd_rand_application_bytes_available_get(p_bytes_available: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 48",
+    core::arch::asm!("svc 48",
         inout("r0") to_asm(p_bytes_available) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1730,7 +1730,7 @@ pub unsafe fn sd_rand_application_bytes_available_get(p_bytes_available: *mut u8
 #[inline(always)]
 pub unsafe fn sd_rand_application_vector_get(p_buff: *mut u8, length: u8) -> u32 {
     let ret: u32;
-    asm!("svc 49",
+    core::arch::asm!("svc 49",
         inout("r0") to_asm(p_buff) => ret,
         inout("r1") to_asm(length) => _,
         lateout("r2") _,
@@ -1748,7 +1748,7 @@ pub unsafe fn sd_rand_application_vector_get(p_buff: *mut u8, length: u8) -> u32
 #[inline(always)]
 pub unsafe fn sd_power_reset_reason_get(p_reset_reason: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 52",
+    core::arch::asm!("svc 52",
         inout("r0") to_asm(p_reset_reason) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1766,7 +1766,7 @@ pub unsafe fn sd_power_reset_reason_get(p_reset_reason: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_reset_reason_clr(reset_reason_clr_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 53",
+    core::arch::asm!("svc 53",
         inout("r0") to_asm(reset_reason_clr_msk) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1785,7 +1785,7 @@ pub unsafe fn sd_power_reset_reason_clr(reset_reason_clr_msk: u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_mode_set(power_mode: u8) -> u32 {
     let ret: u32;
-    asm!("svc 50",
+    core::arch::asm!("svc 50",
         inout("r0") to_asm(power_mode) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1801,7 +1801,7 @@ pub unsafe fn sd_power_mode_set(power_mode: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_system_off() -> u32 {
     let ret: u32;
-    asm!("svc 51",
+    core::arch::asm!("svc 51",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1822,7 +1822,7 @@ pub unsafe fn sd_power_system_off() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_pof_enable(pof_enable: u8) -> u32 {
     let ret: u32;
-    asm!("svc 54",
+    core::arch::asm!("svc 54",
         inout("r0") to_asm(pof_enable) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1845,7 +1845,7 @@ pub unsafe fn sd_power_pof_enable(pof_enable: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_usbpwrrdy_enable(usbpwrrdy_enable: u8) -> u32 {
     let ret: u32;
-    asm!("svc 77",
+    core::arch::asm!("svc 77",
         inout("r0") to_asm(usbpwrrdy_enable) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1868,7 +1868,7 @@ pub unsafe fn sd_power_usbpwrrdy_enable(usbpwrrdy_enable: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_usbdetected_enable(usbdetected_enable: u8) -> u32 {
     let ret: u32;
-    asm!("svc 78",
+    core::arch::asm!("svc 78",
         inout("r0") to_asm(usbdetected_enable) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1891,7 +1891,7 @@ pub unsafe fn sd_power_usbdetected_enable(usbdetected_enable: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_usbremoved_enable(usbremoved_enable: u8) -> u32 {
     let ret: u32;
-    asm!("svc 79",
+    core::arch::asm!("svc 79",
         inout("r0") to_asm(usbremoved_enable) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1911,7 +1911,7 @@ pub unsafe fn sd_power_usbremoved_enable(usbremoved_enable: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_usbregstatus_get(usbregstatus: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 80",
+    core::arch::asm!("svc 80",
         inout("r0") to_asm(usbregstatus) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1931,7 +1931,7 @@ pub unsafe fn sd_power_usbregstatus_get(usbregstatus: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_pof_threshold_set(threshold: u8) -> u32 {
     let ret: u32;
-    asm!("svc 55",
+    core::arch::asm!("svc 55",
         inout("r0") to_asm(threshold) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1950,7 +1950,7 @@ pub unsafe fn sd_power_pof_threshold_set(threshold: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_ram_power_set(index: u8, ram_powerset: u32) -> u32 {
     let ret: u32;
-    asm!("svc 57",
+    core::arch::asm!("svc 57",
         inout("r0") to_asm(index) => ret,
         inout("r1") to_asm(ram_powerset) => _,
         lateout("r2") _,
@@ -1969,7 +1969,7 @@ pub unsafe fn sd_power_ram_power_set(index: u8, ram_powerset: u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_ram_power_clr(index: u8, ram_powerclr: u32) -> u32 {
     let ret: u32;
-    asm!("svc 58",
+    core::arch::asm!("svc 58",
         inout("r0") to_asm(index) => ret,
         inout("r1") to_asm(ram_powerclr) => _,
         lateout("r2") _,
@@ -1988,7 +1988,7 @@ pub unsafe fn sd_power_ram_power_clr(index: u8, ram_powerclr: u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_ram_power_get(index: u8, p_ram_power: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 59",
+    core::arch::asm!("svc 59",
         inout("r0") to_asm(index) => ret,
         inout("r1") to_asm(p_ram_power) => _,
         lateout("r2") _,
@@ -2007,7 +2007,7 @@ pub unsafe fn sd_power_ram_power_get(index: u8, p_ram_power: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_gpregret_set(gpregret_id: u32, gpregret_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 60",
+    core::arch::asm!("svc 60",
         inout("r0") to_asm(gpregret_id) => ret,
         inout("r1") to_asm(gpregret_msk) => _,
         lateout("r2") _,
@@ -2026,7 +2026,7 @@ pub unsafe fn sd_power_gpregret_set(gpregret_id: u32, gpregret_msk: u32) -> u32 
 #[inline(always)]
 pub unsafe fn sd_power_gpregret_clr(gpregret_id: u32, gpregret_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 61",
+    core::arch::asm!("svc 61",
         inout("r0") to_asm(gpregret_id) => ret,
         inout("r1") to_asm(gpregret_msk) => _,
         lateout("r2") _,
@@ -2045,7 +2045,7 @@ pub unsafe fn sd_power_gpregret_clr(gpregret_id: u32, gpregret_msk: u32) -> u32 
 #[inline(always)]
 pub unsafe fn sd_power_gpregret_get(gpregret_id: u32, p_gpregret: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 62",
+    core::arch::asm!("svc 62",
         inout("r0") to_asm(gpregret_id) => ret,
         inout("r1") to_asm(p_gpregret) => _,
         lateout("r2") _,
@@ -2064,7 +2064,7 @@ pub unsafe fn sd_power_gpregret_get(gpregret_id: u32, p_gpregret: *mut u32) -> u
 #[inline(always)]
 pub unsafe fn sd_power_dcdc_mode_set(dcdc_mode: u8) -> u32 {
     let ret: u32;
-    asm!("svc 63",
+    core::arch::asm!("svc 63",
         inout("r0") to_asm(dcdc_mode) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2086,7 +2086,7 @@ pub unsafe fn sd_power_dcdc_mode_set(dcdc_mode: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_clock_hfclk_request() -> u32 {
     let ret: u32;
-    asm!("svc 66",
+    core::arch::asm!("svc 66",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2107,7 +2107,7 @@ pub unsafe fn sd_clock_hfclk_request() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_clock_hfclk_release() -> u32 {
     let ret: u32;
-    asm!("svc 67",
+    core::arch::asm!("svc 67",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2128,7 +2128,7 @@ pub unsafe fn sd_clock_hfclk_release() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_clock_hfclk_is_running(p_is_running: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 68",
+    core::arch::asm!("svc 68",
         inout("r0") to_asm(p_is_running) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2166,7 +2166,7 @@ pub unsafe fn sd_clock_hfclk_is_running(p_is_running: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_app_evt_wait() -> u32 {
     let ret: u32;
-    asm!("svc 65",
+    core::arch::asm!("svc 65",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2184,7 +2184,7 @@ pub unsafe fn sd_app_evt_wait() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_channel_enable_get(p_channel_enable: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 32",
+    core::arch::asm!("svc 32",
         inout("r0") to_asm(p_channel_enable) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2202,7 +2202,7 @@ pub unsafe fn sd_ppi_channel_enable_get(p_channel_enable: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_channel_enable_set(channel_enable_set_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 33",
+    core::arch::asm!("svc 33",
         inout("r0") to_asm(channel_enable_set_msk) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2220,7 +2220,7 @@ pub unsafe fn sd_ppi_channel_enable_set(channel_enable_set_msk: u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_channel_enable_clr(channel_enable_clr_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 34",
+    core::arch::asm!("svc 34",
         inout("r0") to_asm(channel_enable_clr_msk) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2245,7 +2245,7 @@ pub unsafe fn sd_ppi_channel_assign(
     task_endpoint: *const self::c_void,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 35",
+    core::arch::asm!("svc 35",
         inout("r0") to_asm(channel_num) => ret,
         inout("r1") to_asm(evt_endpoint) => _,
         inout("r2") to_asm(task_endpoint) => _,
@@ -2264,7 +2264,7 @@ pub unsafe fn sd_ppi_channel_assign(
 #[inline(always)]
 pub unsafe fn sd_ppi_group_task_enable(group_num: u8) -> u32 {
     let ret: u32;
-    asm!("svc 36",
+    core::arch::asm!("svc 36",
         inout("r0") to_asm(group_num) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2283,7 +2283,7 @@ pub unsafe fn sd_ppi_group_task_enable(group_num: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_group_task_disable(group_num: u8) -> u32 {
     let ret: u32;
-    asm!("svc 37",
+    core::arch::asm!("svc 37",
         inout("r0") to_asm(group_num) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2303,7 +2303,7 @@ pub unsafe fn sd_ppi_group_task_disable(group_num: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_group_assign(group_num: u8, channel_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 38",
+    core::arch::asm!("svc 38",
         inout("r0") to_asm(group_num) => ret,
         inout("r1") to_asm(channel_msk) => _,
         lateout("r2") _,
@@ -2323,7 +2323,7 @@ pub unsafe fn sd_ppi_group_assign(group_num: u8, channel_msk: u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_group_get(group_num: u8, p_channel_msk: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 39",
+    core::arch::asm!("svc 39",
         inout("r0") to_asm(group_num) => ret,
         inout("r1") to_asm(p_channel_msk) => _,
         lateout("r2") _,
@@ -2364,7 +2364,7 @@ pub unsafe fn sd_ppi_group_get(group_num: u8, p_channel_msk: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_radio_notification_cfg_set(type_: u8, distance: u8) -> u32 {
     let ret: u32;
-    asm!("svc 69",
+    core::arch::asm!("svc 69",
         inout("r0") to_asm(type_) => ret,
         inout("r1") to_asm(distance) => _,
         lateout("r2") _,
@@ -2390,7 +2390,7 @@ pub unsafe fn sd_radio_notification_cfg_set(type_: u8, distance: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ecb_block_encrypt(p_ecb_data: *mut nrf_ecb_hal_data_t) -> u32 {
     let ret: u32;
-    asm!("svc 70",
+    core::arch::asm!("svc 70",
         inout("r0") to_asm(p_ecb_data) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2420,7 +2420,7 @@ pub unsafe fn sd_ecb_blocks_encrypt(
     p_data_blocks: *mut nrf_ecb_hal_data_block_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 71",
+    core::arch::asm!("svc 71",
         inout("r0") to_asm(block_count) => ret,
         inout("r1") to_asm(p_data_blocks) => _,
         lateout("r2") _,
@@ -2441,7 +2441,7 @@ pub unsafe fn sd_ecb_blocks_encrypt(
 #[inline(always)]
 pub unsafe fn sd_evt_get(p_evt_id: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 75",
+    core::arch::asm!("svc 75",
         inout("r0") to_asm(p_evt_id) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2462,7 +2462,7 @@ pub unsafe fn sd_evt_get(p_evt_id: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_temp_get(p_temp: *mut i32) -> u32 {
     let ret: u32;
-    asm!("svc 76",
+    core::arch::asm!("svc 76",
         inout("r0") to_asm(p_temp) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2509,7 +2509,7 @@ pub unsafe fn sd_temp_get(p_temp: *mut i32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_flash_write(p_dst: *mut u32, p_src: *const u32, size: u32) -> u32 {
     let ret: u32;
-    asm!("svc 41",
+    core::arch::asm!("svc 41",
         inout("r0") to_asm(p_dst) => ret,
         inout("r1") to_asm(p_src) => _,
         inout("r2") to_asm(size) => _,
@@ -2550,7 +2550,7 @@ pub unsafe fn sd_flash_write(p_dst: *mut u32, p_src: *const u32, size: u32) -> u
 #[inline(always)]
 pub unsafe fn sd_flash_page_erase(page_number: u32) -> u32 {
     let ret: u32;
-    asm!("svc 40",
+    core::arch::asm!("svc 40",
         inout("r0") to_asm(page_number) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2582,7 +2582,7 @@ pub unsafe fn sd_flash_page_erase(page_number: u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_radio_session_open(p_radio_signal_callback: nrf_radio_signal_callback_t) -> u32 {
     let ret: u32;
-    asm!("svc 72",
+    core::arch::asm!("svc 72",
         inout("r0") to_asm(p_radio_signal_callback) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2605,7 +2605,7 @@ pub unsafe fn sd_radio_session_open(p_radio_signal_callback: nrf_radio_signal_ca
 #[inline(always)]
 pub unsafe fn sd_radio_session_close() -> u32 {
     let ret: u32;
-    asm!("svc 73",
+    core::arch::asm!("svc 73",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2652,7 +2652,7 @@ pub unsafe fn sd_radio_session_close() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_radio_request(p_request: *const nrf_radio_request_t) -> u32 {
     let ret: u32;
-    asm!("svc 74",
+    core::arch::asm!("svc 74",
         inout("r0") to_asm(p_request) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2683,7 +2683,7 @@ pub unsafe fn sd_radio_request(p_request: *const nrf_radio_request_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_protected_register_write(p_register: *mut u32, value: u32) -> u32 {
     let ret: u32;
-    asm!("svc 43",
+    core::arch::asm!("svc 43",
         inout("r0") to_asm(p_register) => ret,
         inout("r1") to_asm(value) => _,
         lateout("r2") _,
@@ -2853,7 +2853,7 @@ pub unsafe fn sd_softdevice_enable(
     fault_handler: nrf_fault_handler_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 16",
+    core::arch::asm!("svc 16",
         inout("r0") to_asm(p_clock_lf_cfg) => ret,
         inout("r1") to_asm(fault_handler) => _,
         lateout("r2") _,
@@ -2878,7 +2878,7 @@ pub unsafe fn sd_softdevice_enable(
 #[inline(always)]
 pub unsafe fn sd_softdevice_disable() -> u32 {
     let ret: u32;
-    asm!("svc 17",
+    core::arch::asm!("svc 17",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2896,7 +2896,7 @@ pub unsafe fn sd_softdevice_disable() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_softdevice_is_enabled(p_softdevice_enabled: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 18",
+    core::arch::asm!("svc 18",
         inout("r0") to_asm(p_softdevice_enabled) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2916,7 +2916,7 @@ pub unsafe fn sd_softdevice_is_enabled(p_softdevice_enabled: *mut u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_softdevice_vector_table_base_set(address: u32) -> u32 {
     let ret: u32;
-    asm!("svc 19",
+    core::arch::asm!("svc 19",
         inout("r0") to_asm(address) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -3744,7 +3744,7 @@ fn bindgen_test_layout_sd_mbr_command_t() {
 #[inline(always)]
 pub unsafe fn sd_mbr_command(param: *mut sd_mbr_command_t) -> u32 {
     let ret: u32;
-    asm!("svc 24",
+    core::arch::asm!("svc 24",
         inout("r0") to_asm(param) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -8188,7 +8188,7 @@ fn bindgen_test_layout_ble_gap_qos_params_t() {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_addr_set(p_addr: *const ble_gap_addr_t) -> u32 {
     let ret: u32;
-    asm!("svc 108",
+    core::arch::asm!("svc 108",
         inout("r0") to_asm(p_addr) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -8210,7 +8210,7 @@ pub unsafe fn sd_ble_gap_addr_set(p_addr: *const ble_gap_addr_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_addr_get(p_addr: *mut ble_gap_addr_t) -> u32 {
     let ret: u32;
-    asm!("svc 109",
+    core::arch::asm!("svc 109",
         inout("r0") to_asm(p_addr) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -8244,7 +8244,7 @@ pub unsafe fn sd_ble_gap_addr_get(p_addr: *mut ble_gap_addr_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_whitelist_set(pp_wl_addrs: *const *const ble_gap_addr_t, len: u8) -> u32 {
     let ret: u32;
-    asm!("svc 111",
+    core::arch::asm!("svc 111",
         inout("r0") to_asm(pp_wl_addrs) => ret,
         inout("r1") to_asm(len) => _,
         lateout("r2") _,
@@ -8285,7 +8285,7 @@ pub unsafe fn sd_ble_gap_device_identities_set(
     len: u8,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 112",
+    core::arch::asm!("svc 112",
         inout("r0") to_asm(pp_id_keys) => ret,
         inout("r1") to_asm(pp_local_irks) => _,
         inout("r2") to_asm(len) => _,
@@ -8320,7 +8320,7 @@ pub unsafe fn sd_ble_gap_device_identities_set(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_privacy_set(p_privacy_params: *const ble_gap_privacy_params_t) -> u32 {
     let ret: u32;
-    asm!("svc 113",
+    core::arch::asm!("svc 113",
         inout("r0") to_asm(p_privacy_params) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -8343,7 +8343,7 @@ pub unsafe fn sd_ble_gap_privacy_set(p_privacy_params: *const ble_gap_privacy_pa
 #[inline(always)]
 pub unsafe fn sd_ble_gap_privacy_get(p_privacy_params: *mut ble_gap_privacy_params_t) -> u32 {
     let ret: u32;
-    asm!("svc 114",
+    core::arch::asm!("svc 114",
         inout("r0") to_asm(p_privacy_params) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -8390,7 +8390,7 @@ pub unsafe fn sd_ble_gap_conn_param_update(
     p_conn_params: *const ble_gap_conn_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 118",
+    core::arch::asm!("svc 118",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_conn_params) => _,
         lateout("r2") _,
@@ -8423,7 +8423,7 @@ pub unsafe fn sd_ble_gap_conn_param_update(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_disconnect(conn_handle: u16, hci_status_code: u8) -> u32 {
     let ret: u32;
-    asm!("svc 119",
+    core::arch::asm!("svc 119",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(hci_status_code) => _,
         lateout("r2") _,
@@ -8454,7 +8454,7 @@ pub unsafe fn sd_ble_gap_disconnect(conn_handle: u16, hci_status_code: u8) -> u3
 #[inline(always)]
 pub unsafe fn sd_ble_gap_tx_power_set(role: u8, handle: u16, tx_power: i8) -> u32 {
     let ret: u32;
-    asm!("svc 120",
+    core::arch::asm!("svc 120",
         inout("r0") to_asm(role) => ret,
         inout("r1") to_asm(handle) => _,
         inout("r2") to_asm(tx_power) => _,
@@ -8473,7 +8473,7 @@ pub unsafe fn sd_ble_gap_tx_power_set(role: u8, handle: u16, tx_power: i8) -> u3
 #[inline(always)]
 pub unsafe fn sd_ble_gap_appearance_set(appearance: u16) -> u32 {
     let ret: u32;
-    asm!("svc 121",
+    core::arch::asm!("svc 121",
         inout("r0") to_asm(appearance) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -8492,7 +8492,7 @@ pub unsafe fn sd_ble_gap_appearance_set(appearance: u16) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_appearance_get(p_appearance: *mut u16) -> u32 {
     let ret: u32;
-    asm!("svc 122",
+    core::arch::asm!("svc 122",
         inout("r0") to_asm(p_appearance) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -8523,7 +8523,7 @@ pub unsafe fn sd_ble_gap_device_name_set(
     len: u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 125",
+    core::arch::asm!("svc 125",
         inout("r0") to_asm(p_write_perm) => ret,
         inout("r1") to_asm(p_dev_name) => _,
         inout("r2") to_asm(len) => _,
@@ -8549,7 +8549,7 @@ pub unsafe fn sd_ble_gap_device_name_set(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_device_name_get(p_dev_name: *mut u8, p_len: *mut u16) -> u32 {
     let ret: u32;
-    asm!("svc 126",
+    core::arch::asm!("svc 126",
         inout("r0") to_asm(p_dev_name) => ret,
         inout("r1") to_asm(p_len) => _,
         lateout("r2") _,
@@ -8613,7 +8613,7 @@ pub unsafe fn sd_ble_gap_authenticate(
     p_sec_params: *const ble_gap_sec_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 127",
+    core::arch::asm!("svc 127",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_sec_params) => _,
         lateout("r2") _,
@@ -8675,7 +8675,7 @@ pub unsafe fn sd_ble_gap_sec_params_reply(
     p_sec_keyset: *const ble_gap_sec_keyset_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 128",
+    core::arch::asm!("svc 128",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(sec_status) => _,
         inout("r2") to_asm(p_sec_params) => _,
@@ -8715,7 +8715,7 @@ pub unsafe fn sd_ble_gap_sec_params_reply(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_auth_key_reply(conn_handle: u16, key_type: u8, p_key: *const u8) -> u32 {
     let ret: u32;
-    asm!("svc 129",
+    core::arch::asm!("svc 129",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(key_type) => _,
         inout("r2") to_asm(p_key) => _,
@@ -8758,7 +8758,7 @@ pub unsafe fn sd_ble_gap_lesc_dhkey_reply(
     p_dhkey: *const ble_gap_lesc_dhkey_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 130",
+    core::arch::asm!("svc 130",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_dhkey) => _,
         lateout("r2") _,
@@ -8788,7 +8788,7 @@ pub unsafe fn sd_ble_gap_lesc_dhkey_reply(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_keypress_notify(conn_handle: u16, kp_not: u8) -> u32 {
     let ret: u32;
-    asm!("svc 131",
+    core::arch::asm!("svc 131",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(kp_not) => _,
         lateout("r2") _,
@@ -8821,7 +8821,7 @@ pub unsafe fn sd_ble_gap_lesc_oob_data_get(
     p_oobd_own: *mut ble_gap_lesc_oob_data_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 132",
+    core::arch::asm!("svc 132",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_pk_own) => _,
         inout("r2") to_asm(p_oobd_own) => _,
@@ -8866,7 +8866,7 @@ pub unsafe fn sd_ble_gap_lesc_oob_data_set(
     p_oobd_peer: *const ble_gap_lesc_oob_data_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 133",
+    core::arch::asm!("svc 133",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_oobd_own) => _,
         inout("r2") to_asm(p_oobd_peer) => _,
@@ -8909,7 +8909,7 @@ pub unsafe fn sd_ble_gap_encrypt(
     p_enc_info: *const ble_gap_enc_info_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 134",
+    core::arch::asm!("svc 134",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_master_id) => _,
         inout("r2") to_asm(p_enc_info) => _,
@@ -8933,7 +8933,7 @@ pub unsafe fn sd_ble_gap_conn_sec_get(
     p_conn_sec: *mut ble_gap_conn_sec_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 136",
+    core::arch::asm!("svc 136",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_conn_sec) => _,
         lateout("r2") _,
@@ -8964,7 +8964,7 @@ pub unsafe fn sd_ble_gap_conn_sec_get(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_rssi_get(conn_handle: u16, p_rssi: *mut i8, p_ch_index: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 143",
+    core::arch::asm!("svc 143",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_rssi) => _,
         inout("r2") to_asm(p_ch_index) => _,
@@ -9025,7 +9025,7 @@ pub unsafe fn sd_ble_gap_scan_start(
     p_adv_report_buffer: *const ble_data_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 137",
+    core::arch::asm!("svc 137",
         inout("r0") to_asm(p_scan_params) => ret,
         inout("r1") to_asm(p_adv_report_buffer) => _,
         lateout("r2") _,
@@ -9048,7 +9048,7 @@ pub unsafe fn sd_ble_gap_scan_start(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_scan_stop() -> u32 {
     let ret: u32;
-    asm!("svc 138",
+    core::arch::asm!("svc 138",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -9108,7 +9108,7 @@ pub unsafe fn sd_ble_gap_connect(
     conn_cfg_tag: u8,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 139",
+    core::arch::asm!("svc 139",
         inout("r0") to_asm(p_peer_addr) => ret,
         inout("r1") to_asm(p_scan_params) => _,
         inout("r2") to_asm(p_conn_params) => _,
@@ -9130,7 +9130,7 @@ pub unsafe fn sd_ble_gap_connect(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_connect_cancel() -> u32 {
     let ret: u32;
-    asm!("svc 140",
+    core::arch::asm!("svc 140",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -9194,7 +9194,7 @@ pub unsafe fn sd_ble_gap_connect_cancel() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_phy_update(conn_handle: u16, p_gap_phys: *const ble_gap_phys_t) -> u32 {
     let ret: u32;
-    asm!("svc 141",
+    core::arch::asm!("svc 141",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_gap_phys) => _,
         lateout("r2") _,
@@ -9219,7 +9219,7 @@ pub unsafe fn sd_ble_gap_phy_update(conn_handle: u16, p_gap_phys: *const ble_gap
 #[inline(always)]
 pub unsafe fn sd_ble_gap_qos_start(qos_id: u32, p_qos_params: *const ble_gap_qos_params_t) -> u32 {
     let ret: u32;
-    asm!("svc 144",
+    core::arch::asm!("svc 144",
         inout("r0") to_asm(qos_id) => ret,
         inout("r1") to_asm(p_qos_params) => _,
         lateout("r2") _,
@@ -9244,7 +9244,7 @@ pub unsafe fn sd_ble_gap_qos_start(qos_id: u32, p_qos_params: *const ble_gap_qos
 #[inline(always)]
 pub unsafe fn sd_ble_gap_qos_stop(qos_id: u32, p_qos_params: *const ble_gap_qos_params_t) -> u32 {
     let ret: u32;
-    asm!("svc 145",
+    core::arch::asm!("svc 145",
         inout("r0") to_asm(qos_id) => ret,
         inout("r1") to_asm(p_qos_params) => _,
         lateout("r2") _,
@@ -9277,7 +9277,7 @@ pub unsafe fn sd_ble_gap_qos_stop(qos_id: u32, p_qos_params: *const ble_gap_qos_
 #[inline(always)]
 pub unsafe fn sd_ble_gap_next_conn_evt_counter_get(conn_handle: u16, p_counter: *mut u16) -> u32 {
     let ret: u32;
-    asm!("svc 147",
+    core::arch::asm!("svc 147",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_counter) => _,
         lateout("r2") _,
@@ -9319,7 +9319,7 @@ pub unsafe fn sd_ble_gap_evt_trigger_start(
     p_params: *const ble_gap_event_trigger_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 148",
+    core::arch::asm!("svc 148",
         inout("r0") to_asm(role) => ret,
         inout("r1") to_asm(handle) => _,
         inout("r2") to_asm(p_params) => _,
@@ -9346,7 +9346,7 @@ pub unsafe fn sd_ble_gap_evt_trigger_start(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_evt_trigger_stop(role: u8, handle: u16) -> u32 {
     let ret: u32;
-    asm!("svc 149",
+    core::arch::asm!("svc 149",
         inout("r0") to_asm(role) => ret,
         inout("r1") to_asm(handle) => _,
         lateout("r2") _,
@@ -11011,7 +11011,7 @@ pub unsafe fn sd_ble_gattc_primary_services_discover(
     p_srvc_uuid: *const ble_uuid_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 155",
+    core::arch::asm!("svc 155",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(start_handle) => _,
         inout("r2") to_asm(p_srvc_uuid) => _,
@@ -11050,7 +11050,7 @@ pub unsafe fn sd_ble_gattc_relationships_discover(
     p_handle_range: *const ble_gattc_handle_range_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 156",
+    core::arch::asm!("svc 156",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_handle_range) => _,
         lateout("r2") _,
@@ -11091,7 +11091,7 @@ pub unsafe fn sd_ble_gattc_characteristics_discover(
     p_handle_range: *const ble_gattc_handle_range_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 157",
+    core::arch::asm!("svc 157",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_handle_range) => _,
         lateout("r2") _,
@@ -11129,7 +11129,7 @@ pub unsafe fn sd_ble_gattc_descriptors_discover(
     p_handle_range: *const ble_gattc_handle_range_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 158",
+    core::arch::asm!("svc 158",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_handle_range) => _,
         lateout("r2") _,
@@ -11169,7 +11169,7 @@ pub unsafe fn sd_ble_gattc_char_value_by_uuid_read(
     p_handle_range: *const ble_gattc_handle_range_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 160",
+    core::arch::asm!("svc 160",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_uuid) => _,
         inout("r2") to_asm(p_handle_range) => _,
@@ -11205,7 +11205,7 @@ pub unsafe fn sd_ble_gattc_char_value_by_uuid_read(
 #[inline(always)]
 pub unsafe fn sd_ble_gattc_read(conn_handle: u16, handle: u16, offset: u16) -> u32 {
     let ret: u32;
-    asm!("svc 161",
+    core::arch::asm!("svc 161",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(handle) => _,
         inout("r2") to_asm(offset) => _,
@@ -11244,7 +11244,7 @@ pub unsafe fn sd_ble_gattc_char_values_read(
     handle_count: u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 162",
+    core::arch::asm!("svc 162",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_handles) => _,
         inout("r2") to_asm(handle_count) => _,
@@ -11303,7 +11303,7 @@ pub unsafe fn sd_ble_gattc_write(
     p_write_params: *const ble_gattc_write_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 163",
+    core::arch::asm!("svc 163",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_write_params) => _,
         lateout("r2") _,
@@ -11330,7 +11330,7 @@ pub unsafe fn sd_ble_gattc_write(
 #[inline(always)]
 pub unsafe fn sd_ble_gattc_hv_confirm(conn_handle: u16, handle: u16) -> u32 {
     let ret: u32;
-    asm!("svc 164",
+    core::arch::asm!("svc 164",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(handle) => _,
         lateout("r2") _,
@@ -11361,7 +11361,7 @@ pub unsafe fn sd_ble_gattc_attr_info_discover(
     p_handle_range: *const ble_gattc_handle_range_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 159",
+    core::arch::asm!("svc 159",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_handle_range) => _,
         lateout("r2") _,
@@ -11404,7 +11404,7 @@ pub unsafe fn sd_ble_gattc_attr_info_discover(
 #[inline(always)]
 pub unsafe fn sd_ble_gattc_exchange_mtu_request(conn_handle: u16, client_rx_mtu: u16) -> u32 {
     let ret: u32;
-    asm!("svc 165",
+    core::arch::asm!("svc 165",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(client_rx_mtu) => _,
         lateout("r2") _,
@@ -13085,7 +13085,7 @@ pub unsafe fn sd_ble_gatts_service_add(
     p_handle: *mut u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 168",
+    core::arch::asm!("svc 168",
         inout("r0") to_asm(type_) => ret,
         inout("r1") to_asm(p_uuid) => _,
         inout("r2") to_asm(p_handle) => _,
@@ -13124,7 +13124,7 @@ pub unsafe fn sd_ble_gatts_include_add(
     p_include_handle: *mut u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 169",
+    core::arch::asm!("svc 169",
         inout("r0") to_asm(service_handle) => ret,
         inout("r1") to_asm(inc_srvc_handle) => _,
         inout("r2") to_asm(p_include_handle) => _,
@@ -13167,7 +13167,7 @@ pub unsafe fn sd_ble_gatts_characteristic_add(
     p_handles: *mut ble_gatts_char_handles_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 170",
+    core::arch::asm!("svc 170",
         inout("r0") to_asm(service_handle) => ret,
         inout("r1") to_asm(p_char_md) => _,
         inout("r2") to_asm(p_attr_char_value) => _,
@@ -13203,7 +13203,7 @@ pub unsafe fn sd_ble_gatts_descriptor_add(
     p_handle: *mut u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 171",
+    core::arch::asm!("svc 171",
         inout("r0") to_asm(char_handle) => ret,
         inout("r1") to_asm(p_attr) => _,
         inout("r2") to_asm(p_handle) => _,
@@ -13240,7 +13240,7 @@ pub unsafe fn sd_ble_gatts_value_set(
     p_value: *mut ble_gatts_value_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 172",
+    core::arch::asm!("svc 172",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(handle) => _,
         inout("r2") to_asm(p_value) => _,
@@ -13278,7 +13278,7 @@ pub unsafe fn sd_ble_gatts_value_get(
     p_value: *mut ble_gatts_value_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 173",
+    core::arch::asm!("svc 173",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(handle) => _,
         inout("r2") to_asm(p_value) => _,
@@ -13356,7 +13356,7 @@ pub unsafe fn sd_ble_gatts_hvx(
     p_hvx_params: *const ble_gatts_hvx_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 174",
+    core::arch::asm!("svc 174",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_hvx_params) => _,
         lateout("r2") _,
@@ -13406,7 +13406,7 @@ pub unsafe fn sd_ble_gatts_service_changed(
     end_handle: u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 175",
+    core::arch::asm!("svc 175",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(start_handle) => _,
         inout("r2") to_asm(end_handle) => _,
@@ -13452,7 +13452,7 @@ pub unsafe fn sd_ble_gatts_rw_authorize_reply(
     p_rw_authorize_reply_params: *const ble_gatts_rw_authorize_reply_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 176",
+    core::arch::asm!("svc 176",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_rw_authorize_reply_params) => _,
         lateout("r2") _,
@@ -13510,7 +13510,7 @@ pub unsafe fn sd_ble_gatts_sys_attr_set(
     flags: u32,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 177",
+    core::arch::asm!("svc 177",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_sys_attr_data) => _,
         inout("r2") to_asm(len) => _,
@@ -13557,7 +13557,7 @@ pub unsafe fn sd_ble_gatts_sys_attr_get(
     flags: u32,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 178",
+    core::arch::asm!("svc 178",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_sys_attr_data) => _,
         inout("r2") to_asm(p_len) => _,
@@ -13576,7 +13576,7 @@ pub unsafe fn sd_ble_gatts_sys_attr_get(
 #[inline(always)]
 pub unsafe fn sd_ble_gatts_initial_user_handle_get(p_handle: *mut u16) -> u32 {
     let ret: u32;
-    asm!("svc 179",
+    core::arch::asm!("svc 179",
         inout("r0") to_asm(p_handle) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -13603,7 +13603,7 @@ pub unsafe fn sd_ble_gatts_attr_get(
     p_md: *mut ble_gatts_attr_md_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 180",
+    core::arch::asm!("svc 180",
         inout("r0") to_asm(handle) => ret,
         inout("r1") to_asm(p_uuid) => _,
         inout("r2") to_asm(p_md) => _,
@@ -13643,7 +13643,7 @@ pub unsafe fn sd_ble_gatts_attr_get(
 #[inline(always)]
 pub unsafe fn sd_ble_gatts_exchange_mtu_reply(conn_handle: u16, server_rx_mtu: u16) -> u32 {
     let ret: u32;
-    asm!("svc 181",
+    core::arch::asm!("svc 181",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(server_rx_mtu) => _,
         lateout("r2") _,
@@ -14759,7 +14759,7 @@ fn bindgen_test_layout_ble_cfg_t() {
 #[inline(always)]
 pub unsafe fn sd_ble_enable(p_app_ram_base: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 96",
+    core::arch::asm!("svc 96",
         inout("r0") to_asm(p_app_ram_base) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -14805,7 +14805,7 @@ pub unsafe fn sd_ble_enable(p_app_ram_base: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_cfg_set(cfg_id: u32, p_cfg: *const ble_cfg_t, app_ram_base: u32) -> u32 {
     let ret: u32;
-    asm!("svc 106",
+    core::arch::asm!("svc 106",
         inout("r0") to_asm(cfg_id) => ret,
         inout("r1") to_asm(p_cfg) => _,
         inout("r2") to_asm(app_ram_base) => _,
@@ -14853,7 +14853,7 @@ pub unsafe fn sd_ble_cfg_set(cfg_id: u32, p_cfg: *const ble_cfg_t, app_ram_base:
 #[inline(always)]
 pub unsafe fn sd_ble_evt_get(p_dest: *mut u8, p_len: *mut u16) -> u32 {
     let ret: u32;
-    asm!("svc 97",
+    core::arch::asm!("svc 97",
         inout("r0") to_asm(p_dest) => ret,
         inout("r1") to_asm(p_len) => _,
         lateout("r2") _,
@@ -14891,7 +14891,7 @@ pub unsafe fn sd_ble_evt_get(p_dest: *mut u8, p_len: *mut u16) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_uuid_vs_add(p_vs_uuid: *const ble_uuid128_t, p_uuid_type: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 98",
+    core::arch::asm!("svc 98",
         inout("r0") to_asm(p_vs_uuid) => ret,
         inout("r1") to_asm(p_uuid_type) => _,
         lateout("r2") _,
@@ -14921,7 +14921,7 @@ pub unsafe fn sd_ble_uuid_vs_add(p_vs_uuid: *const ble_uuid128_t, p_uuid_type: *
 #[inline(always)]
 pub unsafe fn sd_ble_uuid_vs_remove(p_uuid_type: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 99",
+    core::arch::asm!("svc 99",
         inout("r0") to_asm(p_uuid_type) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -14955,7 +14955,7 @@ pub unsafe fn sd_ble_uuid_decode(
     p_uuid: *mut ble_uuid_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 100",
+    core::arch::asm!("svc 100",
         inout("r0") to_asm(uuid_le_len) => ret,
         inout("r1") to_asm(p_uuid_le) => _,
         inout("r2") to_asm(p_uuid) => _,
@@ -14983,7 +14983,7 @@ pub unsafe fn sd_ble_uuid_encode(
     p_uuid_le: *mut u8,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 101",
+    core::arch::asm!("svc 101",
         inout("r0") to_asm(p_uuid) => ret,
         inout("r1") to_asm(p_uuid_le_len) => _,
         inout("r2") to_asm(p_uuid_le) => _,
@@ -15005,7 +15005,7 @@ pub unsafe fn sd_ble_uuid_encode(
 #[inline(always)]
 pub unsafe fn sd_ble_version_get(p_version: *mut ble_version_t) -> u32 {
     let ret: u32;
-    asm!("svc 102",
+    core::arch::asm!("svc 102",
         inout("r0") to_asm(p_version) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -15040,7 +15040,7 @@ pub unsafe fn sd_ble_version_get(p_version: *mut ble_version_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_user_mem_reply(conn_handle: u16, p_block: *const ble_user_mem_block_t) -> u32 {
     let ret: u32;
-    asm!("svc 103",
+    core::arch::asm!("svc 103",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_block) => _,
         lateout("r2") _,
@@ -15068,7 +15068,7 @@ pub unsafe fn sd_ble_user_mem_reply(conn_handle: u16, p_block: *const ble_user_m
 #[inline(always)]
 pub unsafe fn sd_ble_opt_set(opt_id: u32, p_opt: *const ble_opt_t) -> u32 {
     let ret: u32;
-    asm!("svc 104",
+    core::arch::asm!("svc 104",
         inout("r0") to_asm(opt_id) => ret,
         inout("r1") to_asm(p_opt) => _,
         lateout("r2") _,
@@ -15097,7 +15097,7 @@ pub unsafe fn sd_ble_opt_set(opt_id: u32, p_opt: *const ble_opt_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_opt_get(opt_id: u32, p_opt: *mut ble_opt_t) -> u32 {
     let ret: u32;
-    asm!("svc 105",
+    core::arch::asm!("svc 105",
         inout("r0") to_asm(opt_id) => ret,
         inout("r1") to_asm(p_opt) => _,
         lateout("r2") _,

--- a/nrf-softdevice-s122/src/lib.rs
+++ b/nrf-softdevice-s122/src/lib.rs
@@ -3,7 +3,6 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_snake_case)]
 #![allow(dead_code)]
-#![feature(asm)]
 
 mod bindings;
 

--- a/nrf-softdevice-s132/src/bindings.rs
+++ b/nrf-softdevice-s132/src/bindings.rs
@@ -1685,7 +1685,7 @@ fn bindgen_test_layout_nrf_ecb_hal_data_block_t() {
 #[inline(always)]
 pub unsafe fn sd_mutex_new(p_mutex: *mut nrf_mutex_t) -> u32 {
     let ret: u32;
-    asm!("svc 44",
+    core::arch::asm!("svc 44",
         inout("r0") to_asm(p_mutex) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1704,7 +1704,7 @@ pub unsafe fn sd_mutex_new(p_mutex: *mut nrf_mutex_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_mutex_acquire(p_mutex: *mut nrf_mutex_t) -> u32 {
     let ret: u32;
-    asm!("svc 45",
+    core::arch::asm!("svc 45",
         inout("r0") to_asm(p_mutex) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1722,7 +1722,7 @@ pub unsafe fn sd_mutex_acquire(p_mutex: *mut nrf_mutex_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_mutex_release(p_mutex: *mut nrf_mutex_t) -> u32 {
     let ret: u32;
-    asm!("svc 46",
+    core::arch::asm!("svc 46",
         inout("r0") to_asm(p_mutex) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1740,7 +1740,7 @@ pub unsafe fn sd_mutex_release(p_mutex: *mut nrf_mutex_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_rand_application_pool_capacity_get(p_pool_capacity: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 47",
+    core::arch::asm!("svc 47",
         inout("r0") to_asm(p_pool_capacity) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1758,7 +1758,7 @@ pub unsafe fn sd_rand_application_pool_capacity_get(p_pool_capacity: *mut u8) ->
 #[inline(always)]
 pub unsafe fn sd_rand_application_bytes_available_get(p_bytes_available: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 48",
+    core::arch::asm!("svc 48",
         inout("r0") to_asm(p_bytes_available) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1778,7 +1778,7 @@ pub unsafe fn sd_rand_application_bytes_available_get(p_bytes_available: *mut u8
 #[inline(always)]
 pub unsafe fn sd_rand_application_vector_get(p_buff: *mut u8, length: u8) -> u32 {
     let ret: u32;
-    asm!("svc 49",
+    core::arch::asm!("svc 49",
         inout("r0") to_asm(p_buff) => ret,
         inout("r1") to_asm(length) => _,
         lateout("r2") _,
@@ -1796,7 +1796,7 @@ pub unsafe fn sd_rand_application_vector_get(p_buff: *mut u8, length: u8) -> u32
 #[inline(always)]
 pub unsafe fn sd_power_reset_reason_get(p_reset_reason: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 52",
+    core::arch::asm!("svc 52",
         inout("r0") to_asm(p_reset_reason) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1814,7 +1814,7 @@ pub unsafe fn sd_power_reset_reason_get(p_reset_reason: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_reset_reason_clr(reset_reason_clr_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 53",
+    core::arch::asm!("svc 53",
         inout("r0") to_asm(reset_reason_clr_msk) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1833,7 +1833,7 @@ pub unsafe fn sd_power_reset_reason_clr(reset_reason_clr_msk: u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_mode_set(power_mode: u8) -> u32 {
     let ret: u32;
-    asm!("svc 50",
+    core::arch::asm!("svc 50",
         inout("r0") to_asm(power_mode) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1849,7 +1849,7 @@ pub unsafe fn sd_power_mode_set(power_mode: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_system_off() -> u32 {
     let ret: u32;
-    asm!("svc 51",
+    core::arch::asm!("svc 51",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1870,7 +1870,7 @@ pub unsafe fn sd_power_system_off() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_pof_enable(pof_enable: u8) -> u32 {
     let ret: u32;
-    asm!("svc 54",
+    core::arch::asm!("svc 54",
         inout("r0") to_asm(pof_enable) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1890,7 +1890,7 @@ pub unsafe fn sd_power_pof_enable(pof_enable: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_pof_threshold_set(threshold: u8) -> u32 {
     let ret: u32;
-    asm!("svc 55",
+    core::arch::asm!("svc 55",
         inout("r0") to_asm(threshold) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1909,7 +1909,7 @@ pub unsafe fn sd_power_pof_threshold_set(threshold: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_ram_power_set(index: u8, ram_powerset: u32) -> u32 {
     let ret: u32;
-    asm!("svc 57",
+    core::arch::asm!("svc 57",
         inout("r0") to_asm(index) => ret,
         inout("r1") to_asm(ram_powerset) => _,
         lateout("r2") _,
@@ -1928,7 +1928,7 @@ pub unsafe fn sd_power_ram_power_set(index: u8, ram_powerset: u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_ram_power_clr(index: u8, ram_powerclr: u32) -> u32 {
     let ret: u32;
-    asm!("svc 58",
+    core::arch::asm!("svc 58",
         inout("r0") to_asm(index) => ret,
         inout("r1") to_asm(ram_powerclr) => _,
         lateout("r2") _,
@@ -1947,7 +1947,7 @@ pub unsafe fn sd_power_ram_power_clr(index: u8, ram_powerclr: u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_ram_power_get(index: u8, p_ram_power: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 59",
+    core::arch::asm!("svc 59",
         inout("r0") to_asm(index) => ret,
         inout("r1") to_asm(p_ram_power) => _,
         lateout("r2") _,
@@ -1966,7 +1966,7 @@ pub unsafe fn sd_power_ram_power_get(index: u8, p_ram_power: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_gpregret_set(gpregret_id: u32, gpregret_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 60",
+    core::arch::asm!("svc 60",
         inout("r0") to_asm(gpregret_id) => ret,
         inout("r1") to_asm(gpregret_msk) => _,
         lateout("r2") _,
@@ -1985,7 +1985,7 @@ pub unsafe fn sd_power_gpregret_set(gpregret_id: u32, gpregret_msk: u32) -> u32 
 #[inline(always)]
 pub unsafe fn sd_power_gpregret_clr(gpregret_id: u32, gpregret_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 61",
+    core::arch::asm!("svc 61",
         inout("r0") to_asm(gpregret_id) => ret,
         inout("r1") to_asm(gpregret_msk) => _,
         lateout("r2") _,
@@ -2004,7 +2004,7 @@ pub unsafe fn sd_power_gpregret_clr(gpregret_id: u32, gpregret_msk: u32) -> u32 
 #[inline(always)]
 pub unsafe fn sd_power_gpregret_get(gpregret_id: u32, p_gpregret: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 62",
+    core::arch::asm!("svc 62",
         inout("r0") to_asm(gpregret_id) => ret,
         inout("r1") to_asm(p_gpregret) => _,
         lateout("r2") _,
@@ -2023,7 +2023,7 @@ pub unsafe fn sd_power_gpregret_get(gpregret_id: u32, p_gpregret: *mut u32) -> u
 #[inline(always)]
 pub unsafe fn sd_power_dcdc_mode_set(dcdc_mode: u8) -> u32 {
     let ret: u32;
-    asm!("svc 63",
+    core::arch::asm!("svc 63",
         inout("r0") to_asm(dcdc_mode) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2045,7 +2045,7 @@ pub unsafe fn sd_power_dcdc_mode_set(dcdc_mode: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_clock_hfclk_request() -> u32 {
     let ret: u32;
-    asm!("svc 66",
+    core::arch::asm!("svc 66",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2066,7 +2066,7 @@ pub unsafe fn sd_clock_hfclk_request() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_clock_hfclk_release() -> u32 {
     let ret: u32;
-    asm!("svc 67",
+    core::arch::asm!("svc 67",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2087,7 +2087,7 @@ pub unsafe fn sd_clock_hfclk_release() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_clock_hfclk_is_running(p_is_running: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 68",
+    core::arch::asm!("svc 68",
         inout("r0") to_asm(p_is_running) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2125,7 +2125,7 @@ pub unsafe fn sd_clock_hfclk_is_running(p_is_running: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_app_evt_wait() -> u32 {
     let ret: u32;
-    asm!("svc 65",
+    core::arch::asm!("svc 65",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2143,7 +2143,7 @@ pub unsafe fn sd_app_evt_wait() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_channel_enable_get(p_channel_enable: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 32",
+    core::arch::asm!("svc 32",
         inout("r0") to_asm(p_channel_enable) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2161,7 +2161,7 @@ pub unsafe fn sd_ppi_channel_enable_get(p_channel_enable: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_channel_enable_set(channel_enable_set_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 33",
+    core::arch::asm!("svc 33",
         inout("r0") to_asm(channel_enable_set_msk) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2179,7 +2179,7 @@ pub unsafe fn sd_ppi_channel_enable_set(channel_enable_set_msk: u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_channel_enable_clr(channel_enable_clr_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 34",
+    core::arch::asm!("svc 34",
         inout("r0") to_asm(channel_enable_clr_msk) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2204,7 +2204,7 @@ pub unsafe fn sd_ppi_channel_assign(
     task_endpoint: *const self::c_void,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 35",
+    core::arch::asm!("svc 35",
         inout("r0") to_asm(channel_num) => ret,
         inout("r1") to_asm(evt_endpoint) => _,
         inout("r2") to_asm(task_endpoint) => _,
@@ -2223,7 +2223,7 @@ pub unsafe fn sd_ppi_channel_assign(
 #[inline(always)]
 pub unsafe fn sd_ppi_group_task_enable(group_num: u8) -> u32 {
     let ret: u32;
-    asm!("svc 36",
+    core::arch::asm!("svc 36",
         inout("r0") to_asm(group_num) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2242,7 +2242,7 @@ pub unsafe fn sd_ppi_group_task_enable(group_num: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_group_task_disable(group_num: u8) -> u32 {
     let ret: u32;
-    asm!("svc 37",
+    core::arch::asm!("svc 37",
         inout("r0") to_asm(group_num) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2262,7 +2262,7 @@ pub unsafe fn sd_ppi_group_task_disable(group_num: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_group_assign(group_num: u8, channel_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 38",
+    core::arch::asm!("svc 38",
         inout("r0") to_asm(group_num) => ret,
         inout("r1") to_asm(channel_msk) => _,
         lateout("r2") _,
@@ -2282,7 +2282,7 @@ pub unsafe fn sd_ppi_group_assign(group_num: u8, channel_msk: u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_group_get(group_num: u8, p_channel_msk: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 39",
+    core::arch::asm!("svc 39",
         inout("r0") to_asm(group_num) => ret,
         inout("r1") to_asm(p_channel_msk) => _,
         lateout("r2") _,
@@ -2323,7 +2323,7 @@ pub unsafe fn sd_ppi_group_get(group_num: u8, p_channel_msk: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_radio_notification_cfg_set(type_: u8, distance: u8) -> u32 {
     let ret: u32;
-    asm!("svc 69",
+    core::arch::asm!("svc 69",
         inout("r0") to_asm(type_) => ret,
         inout("r1") to_asm(distance) => _,
         lateout("r2") _,
@@ -2349,7 +2349,7 @@ pub unsafe fn sd_radio_notification_cfg_set(type_: u8, distance: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ecb_block_encrypt(p_ecb_data: *mut nrf_ecb_hal_data_t) -> u32 {
     let ret: u32;
-    asm!("svc 70",
+    core::arch::asm!("svc 70",
         inout("r0") to_asm(p_ecb_data) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2379,7 +2379,7 @@ pub unsafe fn sd_ecb_blocks_encrypt(
     p_data_blocks: *mut nrf_ecb_hal_data_block_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 71",
+    core::arch::asm!("svc 71",
         inout("r0") to_asm(block_count) => ret,
         inout("r1") to_asm(p_data_blocks) => _,
         lateout("r2") _,
@@ -2400,7 +2400,7 @@ pub unsafe fn sd_ecb_blocks_encrypt(
 #[inline(always)]
 pub unsafe fn sd_evt_get(p_evt_id: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 75",
+    core::arch::asm!("svc 75",
         inout("r0") to_asm(p_evt_id) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2421,7 +2421,7 @@ pub unsafe fn sd_evt_get(p_evt_id: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_temp_get(p_temp: *mut i32) -> u32 {
     let ret: u32;
-    asm!("svc 76",
+    core::arch::asm!("svc 76",
         inout("r0") to_asm(p_temp) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2468,7 +2468,7 @@ pub unsafe fn sd_temp_get(p_temp: *mut i32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_flash_write(p_dst: *mut u32, p_src: *const u32, size: u32) -> u32 {
     let ret: u32;
-    asm!("svc 41",
+    core::arch::asm!("svc 41",
         inout("r0") to_asm(p_dst) => ret,
         inout("r1") to_asm(p_src) => _,
         inout("r2") to_asm(size) => _,
@@ -2509,7 +2509,7 @@ pub unsafe fn sd_flash_write(p_dst: *mut u32, p_src: *const u32, size: u32) -> u
 #[inline(always)]
 pub unsafe fn sd_flash_page_erase(page_number: u32) -> u32 {
     let ret: u32;
-    asm!("svc 40",
+    core::arch::asm!("svc 40",
         inout("r0") to_asm(page_number) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2546,7 +2546,7 @@ pub unsafe fn sd_flash_protect(
     block_cfg3: u32,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 42",
+    core::arch::asm!("svc 42",
         inout("r0") to_asm(block_cfg0) => ret,
         inout("r1") to_asm(block_cfg1) => _,
         inout("r2") to_asm(block_cfg2) => _,
@@ -2578,7 +2578,7 @@ pub unsafe fn sd_flash_protect(
 #[inline(always)]
 pub unsafe fn sd_radio_session_open(p_radio_signal_callback: nrf_radio_signal_callback_t) -> u32 {
     let ret: u32;
-    asm!("svc 72",
+    core::arch::asm!("svc 72",
         inout("r0") to_asm(p_radio_signal_callback) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2601,7 +2601,7 @@ pub unsafe fn sd_radio_session_open(p_radio_signal_callback: nrf_radio_signal_ca
 #[inline(always)]
 pub unsafe fn sd_radio_session_close() -> u32 {
     let ret: u32;
-    asm!("svc 73",
+    core::arch::asm!("svc 73",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2648,7 +2648,7 @@ pub unsafe fn sd_radio_session_close() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_radio_request(p_request: *const nrf_radio_request_t) -> u32 {
     let ret: u32;
-    asm!("svc 74",
+    core::arch::asm!("svc 74",
         inout("r0") to_asm(p_request) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2679,7 +2679,7 @@ pub unsafe fn sd_radio_request(p_request: *const nrf_radio_request_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_protected_register_write(p_register: *mut u32, value: u32) -> u32 {
     let ret: u32;
-    asm!("svc 43",
+    core::arch::asm!("svc 43",
         inout("r0") to_asm(p_register) => ret,
         inout("r1") to_asm(value) => _,
         lateout("r2") _,
@@ -2849,7 +2849,7 @@ pub unsafe fn sd_softdevice_enable(
     fault_handler: nrf_fault_handler_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 16",
+    core::arch::asm!("svc 16",
         inout("r0") to_asm(p_clock_lf_cfg) => ret,
         inout("r1") to_asm(fault_handler) => _,
         lateout("r2") _,
@@ -2874,7 +2874,7 @@ pub unsafe fn sd_softdevice_enable(
 #[inline(always)]
 pub unsafe fn sd_softdevice_disable() -> u32 {
     let ret: u32;
-    asm!("svc 17",
+    core::arch::asm!("svc 17",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2892,7 +2892,7 @@ pub unsafe fn sd_softdevice_disable() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_softdevice_is_enabled(p_softdevice_enabled: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 18",
+    core::arch::asm!("svc 18",
         inout("r0") to_asm(p_softdevice_enabled) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2912,7 +2912,7 @@ pub unsafe fn sd_softdevice_is_enabled(p_softdevice_enabled: *mut u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_softdevice_vector_table_base_set(address: u32) -> u32 {
     let ret: u32;
-    asm!("svc 19",
+    core::arch::asm!("svc 19",
         inout("r0") to_asm(address) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -3740,7 +3740,7 @@ fn bindgen_test_layout_sd_mbr_command_t() {
 #[inline(always)]
 pub unsafe fn sd_mbr_command(param: *mut sd_mbr_command_t) -> u32 {
     let ret: u32;
-    asm!("svc 24",
+    core::arch::asm!("svc 24",
         inout("r0") to_asm(param) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -8977,7 +8977,7 @@ fn bindgen_test_layout_ble_gap_conn_event_trigger_t() {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_addr_set(p_addr: *const ble_gap_addr_t) -> u32 {
     let ret: u32;
-    asm!("svc 108",
+    core::arch::asm!("svc 108",
         inout("r0") to_asm(p_addr) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -8999,7 +8999,7 @@ pub unsafe fn sd_ble_gap_addr_set(p_addr: *const ble_gap_addr_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_addr_get(p_addr: *mut ble_gap_addr_t) -> u32 {
     let ret: u32;
-    asm!("svc 109",
+    core::arch::asm!("svc 109",
         inout("r0") to_asm(p_addr) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -9027,7 +9027,7 @@ pub unsafe fn sd_ble_gap_addr_get(p_addr: *mut ble_gap_addr_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_adv_addr_get(adv_handle: u8, p_addr: *mut ble_gap_addr_t) -> u32 {
     let ret: u32;
-    asm!("svc 147",
+    core::arch::asm!("svc 147",
         inout("r0") to_asm(adv_handle) => ret,
         inout("r1") to_asm(p_addr) => _,
         lateout("r2") _,
@@ -9062,7 +9062,7 @@ pub unsafe fn sd_ble_gap_adv_addr_get(adv_handle: u8, p_addr: *mut ble_gap_addr_
 #[inline(always)]
 pub unsafe fn sd_ble_gap_whitelist_set(pp_wl_addrs: *const *const ble_gap_addr_t, len: u8) -> u32 {
     let ret: u32;
-    asm!("svc 110",
+    core::arch::asm!("svc 110",
         inout("r0") to_asm(pp_wl_addrs) => ret,
         inout("r1") to_asm(len) => _,
         lateout("r2") _,
@@ -9106,7 +9106,7 @@ pub unsafe fn sd_ble_gap_device_identities_set(
     len: u8,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 111",
+    core::arch::asm!("svc 111",
         inout("r0") to_asm(pp_id_keys) => ret,
         inout("r1") to_asm(pp_local_irks) => _,
         inout("r2") to_asm(len) => _,
@@ -9143,7 +9143,7 @@ pub unsafe fn sd_ble_gap_device_identities_set(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_privacy_set(p_privacy_params: *const ble_gap_privacy_params_t) -> u32 {
     let ret: u32;
-    asm!("svc 112",
+    core::arch::asm!("svc 112",
         inout("r0") to_asm(p_privacy_params) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -9166,7 +9166,7 @@ pub unsafe fn sd_ble_gap_privacy_set(p_privacy_params: *const ble_gap_privacy_pa
 #[inline(always)]
 pub unsafe fn sd_ble_gap_privacy_get(p_privacy_params: *mut ble_gap_privacy_params_t) -> u32 {
     let ret: u32;
-    asm!("svc 113",
+    core::arch::asm!("svc 113",
         inout("r0") to_asm(p_privacy_params) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -9226,7 +9226,7 @@ pub unsafe fn sd_ble_gap_adv_set_configure(
     p_adv_params: *const ble_gap_adv_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 114",
+    core::arch::asm!("svc 114",
         inout("r0") to_asm(p_adv_handle) => ret,
         inout("r1") to_asm(p_adv_data) => _,
         inout("r2") to_asm(p_adv_params) => _,
@@ -9282,7 +9282,7 @@ pub unsafe fn sd_ble_gap_adv_set_configure(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_adv_start(adv_handle: u8, conn_cfg_tag: u8) -> u32 {
     let ret: u32;
-    asm!("svc 115",
+    core::arch::asm!("svc 115",
         inout("r0") to_asm(adv_handle) => ret,
         inout("r1") to_asm(conn_cfg_tag) => _,
         lateout("r2") _,
@@ -9307,7 +9307,7 @@ pub unsafe fn sd_ble_gap_adv_start(adv_handle: u8, conn_cfg_tag: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_adv_stop(adv_handle: u8) -> u32 {
     let ret: u32;
-    asm!("svc 116",
+    core::arch::asm!("svc 116",
         inout("r0") to_asm(adv_handle) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -9356,7 +9356,7 @@ pub unsafe fn sd_ble_gap_conn_param_update(
     p_conn_params: *const ble_gap_conn_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 117",
+    core::arch::asm!("svc 117",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_conn_params) => _,
         lateout("r2") _,
@@ -9389,7 +9389,7 @@ pub unsafe fn sd_ble_gap_conn_param_update(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_disconnect(conn_handle: u16, hci_status_code: u8) -> u32 {
     let ret: u32;
-    asm!("svc 118",
+    core::arch::asm!("svc 118",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(hci_status_code) => _,
         lateout("r2") _,
@@ -9423,7 +9423,7 @@ pub unsafe fn sd_ble_gap_disconnect(conn_handle: u16, hci_status_code: u8) -> u3
 #[inline(always)]
 pub unsafe fn sd_ble_gap_tx_power_set(role: u8, handle: u16, tx_power: i8) -> u32 {
     let ret: u32;
-    asm!("svc 119",
+    core::arch::asm!("svc 119",
         inout("r0") to_asm(role) => ret,
         inout("r1") to_asm(handle) => _,
         inout("r2") to_asm(tx_power) => _,
@@ -9442,7 +9442,7 @@ pub unsafe fn sd_ble_gap_tx_power_set(role: u8, handle: u16, tx_power: i8) -> u3
 #[inline(always)]
 pub unsafe fn sd_ble_gap_appearance_set(appearance: u16) -> u32 {
     let ret: u32;
-    asm!("svc 120",
+    core::arch::asm!("svc 120",
         inout("r0") to_asm(appearance) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -9461,7 +9461,7 @@ pub unsafe fn sd_ble_gap_appearance_set(appearance: u16) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_appearance_get(p_appearance: *mut u16) -> u32 {
     let ret: u32;
-    asm!("svc 121",
+    core::arch::asm!("svc 121",
         inout("r0") to_asm(p_appearance) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -9483,7 +9483,7 @@ pub unsafe fn sd_ble_gap_appearance_get(p_appearance: *mut u16) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_ppcp_set(p_conn_params: *const ble_gap_conn_params_t) -> u32 {
     let ret: u32;
-    asm!("svc 122",
+    core::arch::asm!("svc 122",
         inout("r0") to_asm(p_conn_params) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -9504,7 +9504,7 @@ pub unsafe fn sd_ble_gap_ppcp_set(p_conn_params: *const ble_gap_conn_params_t) -
 #[inline(always)]
 pub unsafe fn sd_ble_gap_ppcp_get(p_conn_params: *mut ble_gap_conn_params_t) -> u32 {
     let ret: u32;
-    asm!("svc 123",
+    core::arch::asm!("svc 123",
         inout("r0") to_asm(p_conn_params) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -9535,7 +9535,7 @@ pub unsafe fn sd_ble_gap_device_name_set(
     len: u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 124",
+    core::arch::asm!("svc 124",
         inout("r0") to_asm(p_write_perm) => ret,
         inout("r1") to_asm(p_dev_name) => _,
         inout("r2") to_asm(len) => _,
@@ -9561,7 +9561,7 @@ pub unsafe fn sd_ble_gap_device_name_set(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_device_name_get(p_dev_name: *mut u8, p_len: *mut u16) -> u32 {
     let ret: u32;
-    asm!("svc 125",
+    core::arch::asm!("svc 125",
         inout("r0") to_asm(p_dev_name) => ret,
         inout("r1") to_asm(p_len) => _,
         lateout("r2") _,
@@ -9629,7 +9629,7 @@ pub unsafe fn sd_ble_gap_authenticate(
     p_sec_params: *const ble_gap_sec_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 126",
+    core::arch::asm!("svc 126",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_sec_params) => _,
         lateout("r2") _,
@@ -9706,7 +9706,7 @@ pub unsafe fn sd_ble_gap_sec_params_reply(
     p_sec_keyset: *const ble_gap_sec_keyset_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 127",
+    core::arch::asm!("svc 127",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(sec_status) => _,
         inout("r2") to_asm(p_sec_params) => _,
@@ -9749,7 +9749,7 @@ pub unsafe fn sd_ble_gap_sec_params_reply(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_auth_key_reply(conn_handle: u16, key_type: u8, p_key: *const u8) -> u32 {
     let ret: u32;
-    asm!("svc 128",
+    core::arch::asm!("svc 128",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(key_type) => _,
         inout("r2") to_asm(p_key) => _,
@@ -9797,7 +9797,7 @@ pub unsafe fn sd_ble_gap_lesc_dhkey_reply(
     p_dhkey: *const ble_gap_lesc_dhkey_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 129",
+    core::arch::asm!("svc 129",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_dhkey) => _,
         lateout("r2") _,
@@ -9828,7 +9828,7 @@ pub unsafe fn sd_ble_gap_lesc_dhkey_reply(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_keypress_notify(conn_handle: u16, kp_not: u8) -> u32 {
     let ret: u32;
-    asm!("svc 130",
+    core::arch::asm!("svc 130",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(kp_not) => _,
         lateout("r2") _,
@@ -9862,7 +9862,7 @@ pub unsafe fn sd_ble_gap_lesc_oob_data_get(
     p_oobd_own: *mut ble_gap_lesc_oob_data_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 131",
+    core::arch::asm!("svc 131",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_pk_own) => _,
         inout("r2") to_asm(p_oobd_own) => _,
@@ -9908,7 +9908,7 @@ pub unsafe fn sd_ble_gap_lesc_oob_data_set(
     p_oobd_peer: *const ble_gap_lesc_oob_data_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 132",
+    core::arch::asm!("svc 132",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_oobd_own) => _,
         inout("r2") to_asm(p_oobd_peer) => _,
@@ -9950,7 +9950,7 @@ pub unsafe fn sd_ble_gap_encrypt(
     p_enc_info: *const ble_gap_enc_info_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 133",
+    core::arch::asm!("svc 133",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_master_id) => _,
         inout("r2") to_asm(p_enc_info) => _,
@@ -9990,7 +9990,7 @@ pub unsafe fn sd_ble_gap_sec_info_reply(
     p_sign_info: *const ble_gap_sign_info_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 134",
+    core::arch::asm!("svc 134",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_enc_info) => _,
         inout("r2") to_asm(p_id_info) => _,
@@ -10014,7 +10014,7 @@ pub unsafe fn sd_ble_gap_conn_sec_get(
     p_conn_sec: *mut ble_gap_conn_sec_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 135",
+    core::arch::asm!("svc 135",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_conn_sec) => _,
         lateout("r2") _,
@@ -10049,7 +10049,7 @@ pub unsafe fn sd_ble_gap_conn_sec_get(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_rssi_start(conn_handle: u16, threshold_dbm: u8, skip_count: u8) -> u32 {
     let ret: u32;
-    asm!("svc 136",
+    core::arch::asm!("svc 136",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(threshold_dbm) => _,
         inout("r2") to_asm(skip_count) => _,
@@ -10077,7 +10077,7 @@ pub unsafe fn sd_ble_gap_rssi_start(conn_handle: u16, threshold_dbm: u8, skip_co
 #[inline(always)]
 pub unsafe fn sd_ble_gap_rssi_stop(conn_handle: u16) -> u32 {
     let ret: u32;
-    asm!("svc 137",
+    core::arch::asm!("svc 137",
         inout("r0") to_asm(conn_handle) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -10107,7 +10107,7 @@ pub unsafe fn sd_ble_gap_rssi_stop(conn_handle: u16) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_rssi_get(conn_handle: u16, p_rssi: *mut i8, p_ch_index: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 142",
+    core::arch::asm!("svc 142",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_rssi) => _,
         inout("r2") to_asm(p_ch_index) => _,
@@ -10173,7 +10173,7 @@ pub unsafe fn sd_ble_gap_scan_start(
     p_adv_report_buffer: *const ble_data_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 138",
+    core::arch::asm!("svc 138",
         inout("r0") to_asm(p_scan_params) => ret,
         inout("r1") to_asm(p_adv_report_buffer) => _,
         lateout("r2") _,
@@ -10197,7 +10197,7 @@ pub unsafe fn sd_ble_gap_scan_start(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_scan_stop() -> u32 {
     let ret: u32;
-    asm!("svc 139",
+    core::arch::asm!("svc 139",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -10258,7 +10258,7 @@ pub unsafe fn sd_ble_gap_connect(
     conn_cfg_tag: u8,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 140",
+    core::arch::asm!("svc 140",
         inout("r0") to_asm(p_peer_addr) => ret,
         inout("r1") to_asm(p_scan_params) => _,
         inout("r2") to_asm(p_conn_params) => _,
@@ -10280,7 +10280,7 @@ pub unsafe fn sd_ble_gap_connect(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_connect_cancel() -> u32 {
     let ret: u32;
-    asm!("svc 141",
+    core::arch::asm!("svc 141",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -10343,7 +10343,7 @@ pub unsafe fn sd_ble_gap_connect_cancel() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_phy_update(conn_handle: u16, p_gap_phys: *const ble_gap_phys_t) -> u32 {
     let ret: u32;
-    asm!("svc 143",
+    core::arch::asm!("svc 143",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_gap_phys) => _,
         lateout("r2") _,
@@ -10391,7 +10391,7 @@ pub unsafe fn sd_ble_gap_data_length_update(
     p_dl_limitation: *mut ble_gap_data_length_limitation_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 144",
+    core::arch::asm!("svc 144",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_dl_params) => _,
         inout("r2") to_asm(p_dl_limitation) => _,
@@ -10433,7 +10433,7 @@ pub unsafe fn sd_ble_gap_data_length_update(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_qos_channel_survey_start(interval_us: u32) -> u32 {
     let ret: u32;
-    asm!("svc 145",
+    core::arch::asm!("svc 145",
         inout("r0") to_asm(interval_us) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -10453,7 +10453,7 @@ pub unsafe fn sd_ble_gap_qos_channel_survey_start(interval_us: u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_qos_channel_survey_stop() -> u32 {
     let ret: u32;
-    asm!("svc 146",
+    core::arch::asm!("svc 146",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -10486,7 +10486,7 @@ pub unsafe fn sd_ble_gap_qos_channel_survey_stop() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_next_conn_evt_counter_get(conn_handle: u16, p_counter: *mut u16) -> u32 {
     let ret: u32;
-    asm!("svc 148",
+    core::arch::asm!("svc 148",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_counter) => _,
         lateout("r2") _,
@@ -10520,7 +10520,7 @@ pub unsafe fn sd_ble_gap_conn_evt_trigger_start(
     p_params: *const ble_gap_conn_event_trigger_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 149",
+    core::arch::asm!("svc 149",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_params) => _,
         lateout("r2") _,
@@ -10540,7 +10540,7 @@ pub unsafe fn sd_ble_gap_conn_evt_trigger_start(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_conn_evt_trigger_stop(conn_handle: u16) -> u32 {
     let ret: u32;
-    asm!("svc 150",
+    core::arch::asm!("svc 150",
         inout("r0") to_asm(conn_handle) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -11401,7 +11401,7 @@ pub unsafe fn sd_ble_l2cap_ch_setup(
     p_params: *const ble_l2cap_ch_setup_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 184",
+    core::arch::asm!("svc 184",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_local_cid) => _,
         inout("r2") to_asm(p_params) => _,
@@ -11434,7 +11434,7 @@ pub unsafe fn sd_ble_l2cap_ch_setup(
 #[inline(always)]
 pub unsafe fn sd_ble_l2cap_ch_release(conn_handle: u16, local_cid: u16) -> u32 {
     let ret: u32;
-    asm!("svc 185",
+    core::arch::asm!("svc 185",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(local_cid) => _,
         lateout("r2") _,
@@ -11482,7 +11482,7 @@ pub unsafe fn sd_ble_l2cap_ch_rx(
     p_sdu_buf: *const ble_data_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 186",
+    core::arch::asm!("svc 186",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(local_cid) => _,
         inout("r2") to_asm(p_sdu_buf) => _,
@@ -11541,7 +11541,7 @@ pub unsafe fn sd_ble_l2cap_ch_tx(
     p_sdu_buf: *const ble_data_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 187",
+    core::arch::asm!("svc 187",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(local_cid) => _,
         inout("r2") to_asm(p_sdu_buf) => _,
@@ -11600,7 +11600,7 @@ pub unsafe fn sd_ble_l2cap_ch_flow_control(
     p_credits: *mut u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 188",
+    core::arch::asm!("svc 188",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(local_cid) => _,
         inout("r2") to_asm(credits) => _,
@@ -13265,7 +13265,7 @@ pub unsafe fn sd_ble_gattc_primary_services_discover(
     p_srvc_uuid: *const ble_uuid_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 155",
+    core::arch::asm!("svc 155",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(start_handle) => _,
         inout("r2") to_asm(p_srvc_uuid) => _,
@@ -13304,7 +13304,7 @@ pub unsafe fn sd_ble_gattc_relationships_discover(
     p_handle_range: *const ble_gattc_handle_range_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 156",
+    core::arch::asm!("svc 156",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_handle_range) => _,
         lateout("r2") _,
@@ -13345,7 +13345,7 @@ pub unsafe fn sd_ble_gattc_characteristics_discover(
     p_handle_range: *const ble_gattc_handle_range_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 157",
+    core::arch::asm!("svc 157",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_handle_range) => _,
         lateout("r2") _,
@@ -13383,7 +13383,7 @@ pub unsafe fn sd_ble_gattc_descriptors_discover(
     p_handle_range: *const ble_gattc_handle_range_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 158",
+    core::arch::asm!("svc 158",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_handle_range) => _,
         lateout("r2") _,
@@ -13423,7 +13423,7 @@ pub unsafe fn sd_ble_gattc_char_value_by_uuid_read(
     p_handle_range: *const ble_gattc_handle_range_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 160",
+    core::arch::asm!("svc 160",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_uuid) => _,
         inout("r2") to_asm(p_handle_range) => _,
@@ -13459,7 +13459,7 @@ pub unsafe fn sd_ble_gattc_char_value_by_uuid_read(
 #[inline(always)]
 pub unsafe fn sd_ble_gattc_read(conn_handle: u16, handle: u16, offset: u16) -> u32 {
     let ret: u32;
-    asm!("svc 161",
+    core::arch::asm!("svc 161",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(handle) => _,
         inout("r2") to_asm(offset) => _,
@@ -13498,7 +13498,7 @@ pub unsafe fn sd_ble_gattc_char_values_read(
     handle_count: u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 162",
+    core::arch::asm!("svc 162",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_handles) => _,
         inout("r2") to_asm(handle_count) => _,
@@ -13557,7 +13557,7 @@ pub unsafe fn sd_ble_gattc_write(
     p_write_params: *const ble_gattc_write_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 163",
+    core::arch::asm!("svc 163",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_write_params) => _,
         lateout("r2") _,
@@ -13584,7 +13584,7 @@ pub unsafe fn sd_ble_gattc_write(
 #[inline(always)]
 pub unsafe fn sd_ble_gattc_hv_confirm(conn_handle: u16, handle: u16) -> u32 {
     let ret: u32;
-    asm!("svc 164",
+    core::arch::asm!("svc 164",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(handle) => _,
         lateout("r2") _,
@@ -13615,7 +13615,7 @@ pub unsafe fn sd_ble_gattc_attr_info_discover(
     p_handle_range: *const ble_gattc_handle_range_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 159",
+    core::arch::asm!("svc 159",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_handle_range) => _,
         lateout("r2") _,
@@ -13658,7 +13658,7 @@ pub unsafe fn sd_ble_gattc_attr_info_discover(
 #[inline(always)]
 pub unsafe fn sd_ble_gattc_exchange_mtu_request(conn_handle: u16, client_rx_mtu: u16) -> u32 {
     let ret: u32;
-    asm!("svc 165",
+    core::arch::asm!("svc 165",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(client_rx_mtu) => _,
         lateout("r2") _,
@@ -15339,7 +15339,7 @@ pub unsafe fn sd_ble_gatts_service_add(
     p_handle: *mut u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 168",
+    core::arch::asm!("svc 168",
         inout("r0") to_asm(type_) => ret,
         inout("r1") to_asm(p_uuid) => _,
         inout("r2") to_asm(p_handle) => _,
@@ -15378,7 +15378,7 @@ pub unsafe fn sd_ble_gatts_include_add(
     p_include_handle: *mut u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 169",
+    core::arch::asm!("svc 169",
         inout("r0") to_asm(service_handle) => ret,
         inout("r1") to_asm(inc_srvc_handle) => _,
         inout("r2") to_asm(p_include_handle) => _,
@@ -15421,7 +15421,7 @@ pub unsafe fn sd_ble_gatts_characteristic_add(
     p_handles: *mut ble_gatts_char_handles_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 170",
+    core::arch::asm!("svc 170",
         inout("r0") to_asm(service_handle) => ret,
         inout("r1") to_asm(p_char_md) => _,
         inout("r2") to_asm(p_attr_char_value) => _,
@@ -15457,7 +15457,7 @@ pub unsafe fn sd_ble_gatts_descriptor_add(
     p_handle: *mut u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 171",
+    core::arch::asm!("svc 171",
         inout("r0") to_asm(char_handle) => ret,
         inout("r1") to_asm(p_attr) => _,
         inout("r2") to_asm(p_handle) => _,
@@ -15494,7 +15494,7 @@ pub unsafe fn sd_ble_gatts_value_set(
     p_value: *mut ble_gatts_value_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 172",
+    core::arch::asm!("svc 172",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(handle) => _,
         inout("r2") to_asm(p_value) => _,
@@ -15532,7 +15532,7 @@ pub unsafe fn sd_ble_gatts_value_get(
     p_value: *mut ble_gatts_value_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 173",
+    core::arch::asm!("svc 173",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(handle) => _,
         inout("r2") to_asm(p_value) => _,
@@ -15610,7 +15610,7 @@ pub unsafe fn sd_ble_gatts_hvx(
     p_hvx_params: *const ble_gatts_hvx_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 174",
+    core::arch::asm!("svc 174",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_hvx_params) => _,
         lateout("r2") _,
@@ -15660,7 +15660,7 @@ pub unsafe fn sd_ble_gatts_service_changed(
     end_handle: u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 175",
+    core::arch::asm!("svc 175",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(start_handle) => _,
         inout("r2") to_asm(end_handle) => _,
@@ -15706,7 +15706,7 @@ pub unsafe fn sd_ble_gatts_rw_authorize_reply(
     p_rw_authorize_reply_params: *const ble_gatts_rw_authorize_reply_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 176",
+    core::arch::asm!("svc 176",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_rw_authorize_reply_params) => _,
         lateout("r2") _,
@@ -15764,7 +15764,7 @@ pub unsafe fn sd_ble_gatts_sys_attr_set(
     flags: u32,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 177",
+    core::arch::asm!("svc 177",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_sys_attr_data) => _,
         inout("r2") to_asm(len) => _,
@@ -15811,7 +15811,7 @@ pub unsafe fn sd_ble_gatts_sys_attr_get(
     flags: u32,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 178",
+    core::arch::asm!("svc 178",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_sys_attr_data) => _,
         inout("r2") to_asm(p_len) => _,
@@ -15830,7 +15830,7 @@ pub unsafe fn sd_ble_gatts_sys_attr_get(
 #[inline(always)]
 pub unsafe fn sd_ble_gatts_initial_user_handle_get(p_handle: *mut u16) -> u32 {
     let ret: u32;
-    asm!("svc 179",
+    core::arch::asm!("svc 179",
         inout("r0") to_asm(p_handle) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -15857,7 +15857,7 @@ pub unsafe fn sd_ble_gatts_attr_get(
     p_md: *mut ble_gatts_attr_md_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 180",
+    core::arch::asm!("svc 180",
         inout("r0") to_asm(handle) => ret,
         inout("r1") to_asm(p_uuid) => _,
         inout("r2") to_asm(p_md) => _,
@@ -15897,7 +15897,7 @@ pub unsafe fn sd_ble_gatts_attr_get(
 #[inline(always)]
 pub unsafe fn sd_ble_gatts_exchange_mtu_reply(conn_handle: u16, server_rx_mtu: u16) -> u32 {
     let ret: u32;
-    asm!("svc 181",
+    core::arch::asm!("svc 181",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(server_rx_mtu) => _,
         lateout("r2") _,
@@ -17103,7 +17103,7 @@ fn bindgen_test_layout_ble_cfg_t() {
 #[inline(always)]
 pub unsafe fn sd_ble_enable(p_app_ram_base: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 96",
+    core::arch::asm!("svc 96",
         inout("r0") to_asm(p_app_ram_base) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -17149,7 +17149,7 @@ pub unsafe fn sd_ble_enable(p_app_ram_base: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_cfg_set(cfg_id: u32, p_cfg: *const ble_cfg_t, app_ram_base: u32) -> u32 {
     let ret: u32;
-    asm!("svc 105",
+    core::arch::asm!("svc 105",
         inout("r0") to_asm(cfg_id) => ret,
         inout("r1") to_asm(p_cfg) => _,
         inout("r2") to_asm(app_ram_base) => _,
@@ -17197,7 +17197,7 @@ pub unsafe fn sd_ble_cfg_set(cfg_id: u32, p_cfg: *const ble_cfg_t, app_ram_base:
 #[inline(always)]
 pub unsafe fn sd_ble_evt_get(p_dest: *mut u8, p_len: *mut u16) -> u32 {
     let ret: u32;
-    asm!("svc 97",
+    core::arch::asm!("svc 97",
         inout("r0") to_asm(p_dest) => ret,
         inout("r1") to_asm(p_len) => _,
         lateout("r2") _,
@@ -17235,7 +17235,7 @@ pub unsafe fn sd_ble_evt_get(p_dest: *mut u8, p_len: *mut u16) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_uuid_vs_add(p_vs_uuid: *const ble_uuid128_t, p_uuid_type: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 98",
+    core::arch::asm!("svc 98",
         inout("r0") to_asm(p_vs_uuid) => ret,
         inout("r1") to_asm(p_uuid_type) => _,
         lateout("r2") _,
@@ -17265,7 +17265,7 @@ pub unsafe fn sd_ble_uuid_vs_add(p_vs_uuid: *const ble_uuid128_t, p_uuid_type: *
 #[inline(always)]
 pub unsafe fn sd_ble_uuid_vs_remove(p_uuid_type: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 106",
+    core::arch::asm!("svc 106",
         inout("r0") to_asm(p_uuid_type) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -17299,7 +17299,7 @@ pub unsafe fn sd_ble_uuid_decode(
     p_uuid: *mut ble_uuid_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 99",
+    core::arch::asm!("svc 99",
         inout("r0") to_asm(uuid_le_len) => ret,
         inout("r1") to_asm(p_uuid_le) => _,
         inout("r2") to_asm(p_uuid) => _,
@@ -17327,7 +17327,7 @@ pub unsafe fn sd_ble_uuid_encode(
     p_uuid_le: *mut u8,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 100",
+    core::arch::asm!("svc 100",
         inout("r0") to_asm(p_uuid) => ret,
         inout("r1") to_asm(p_uuid_le_len) => _,
         inout("r2") to_asm(p_uuid_le) => _,
@@ -17349,7 +17349,7 @@ pub unsafe fn sd_ble_uuid_encode(
 #[inline(always)]
 pub unsafe fn sd_ble_version_get(p_version: *mut ble_version_t) -> u32 {
     let ret: u32;
-    asm!("svc 101",
+    core::arch::asm!("svc 101",
         inout("r0") to_asm(p_version) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -17384,7 +17384,7 @@ pub unsafe fn sd_ble_version_get(p_version: *mut ble_version_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_user_mem_reply(conn_handle: u16, p_block: *const ble_user_mem_block_t) -> u32 {
     let ret: u32;
-    asm!("svc 102",
+    core::arch::asm!("svc 102",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_block) => _,
         lateout("r2") _,
@@ -17410,7 +17410,7 @@ pub unsafe fn sd_ble_user_mem_reply(conn_handle: u16, p_block: *const ble_user_m
 #[inline(always)]
 pub unsafe fn sd_ble_opt_set(opt_id: u32, p_opt: *const ble_opt_t) -> u32 {
     let ret: u32;
-    asm!("svc 103",
+    core::arch::asm!("svc 103",
         inout("r0") to_asm(opt_id) => ret,
         inout("r1") to_asm(p_opt) => _,
         lateout("r2") _,
@@ -17438,7 +17438,7 @@ pub unsafe fn sd_ble_opt_set(opt_id: u32, p_opt: *const ble_opt_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_opt_get(opt_id: u32, p_opt: *mut ble_opt_t) -> u32 {
     let ret: u32;
-    asm!("svc 104",
+    core::arch::asm!("svc 104",
         inout("r0") to_asm(opt_id) => ret,
         inout("r1") to_asm(p_opt) => _,
         lateout("r2") _,

--- a/nrf-softdevice-s132/src/lib.rs
+++ b/nrf-softdevice-s132/src/lib.rs
@@ -3,7 +3,6 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_snake_case)]
 #![allow(dead_code)]
-#![feature(asm)]
 
 mod bindings;
 

--- a/nrf-softdevice-s140/src/bindings.rs
+++ b/nrf-softdevice-s140/src/bindings.rs
@@ -1731,7 +1731,7 @@ fn bindgen_test_layout_nrf_ecb_hal_data_block_t() {
 #[inline(always)]
 pub unsafe fn sd_mutex_new(p_mutex: *mut nrf_mutex_t) -> u32 {
     let ret: u32;
-    asm!("svc 44",
+    core::arch::asm!("svc 44",
         inout("r0") to_asm(p_mutex) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1750,7 +1750,7 @@ pub unsafe fn sd_mutex_new(p_mutex: *mut nrf_mutex_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_mutex_acquire(p_mutex: *mut nrf_mutex_t) -> u32 {
     let ret: u32;
-    asm!("svc 45",
+    core::arch::asm!("svc 45",
         inout("r0") to_asm(p_mutex) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1768,7 +1768,7 @@ pub unsafe fn sd_mutex_acquire(p_mutex: *mut nrf_mutex_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_mutex_release(p_mutex: *mut nrf_mutex_t) -> u32 {
     let ret: u32;
-    asm!("svc 46",
+    core::arch::asm!("svc 46",
         inout("r0") to_asm(p_mutex) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1786,7 +1786,7 @@ pub unsafe fn sd_mutex_release(p_mutex: *mut nrf_mutex_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_rand_application_pool_capacity_get(p_pool_capacity: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 47",
+    core::arch::asm!("svc 47",
         inout("r0") to_asm(p_pool_capacity) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1804,7 +1804,7 @@ pub unsafe fn sd_rand_application_pool_capacity_get(p_pool_capacity: *mut u8) ->
 #[inline(always)]
 pub unsafe fn sd_rand_application_bytes_available_get(p_bytes_available: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 48",
+    core::arch::asm!("svc 48",
         inout("r0") to_asm(p_bytes_available) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1824,7 +1824,7 @@ pub unsafe fn sd_rand_application_bytes_available_get(p_bytes_available: *mut u8
 #[inline(always)]
 pub unsafe fn sd_rand_application_vector_get(p_buff: *mut u8, length: u8) -> u32 {
     let ret: u32;
-    asm!("svc 49",
+    core::arch::asm!("svc 49",
         inout("r0") to_asm(p_buff) => ret,
         inout("r1") to_asm(length) => _,
         lateout("r2") _,
@@ -1842,7 +1842,7 @@ pub unsafe fn sd_rand_application_vector_get(p_buff: *mut u8, length: u8) -> u32
 #[inline(always)]
 pub unsafe fn sd_power_reset_reason_get(p_reset_reason: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 52",
+    core::arch::asm!("svc 52",
         inout("r0") to_asm(p_reset_reason) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1860,7 +1860,7 @@ pub unsafe fn sd_power_reset_reason_get(p_reset_reason: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_reset_reason_clr(reset_reason_clr_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 53",
+    core::arch::asm!("svc 53",
         inout("r0") to_asm(reset_reason_clr_msk) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1879,7 +1879,7 @@ pub unsafe fn sd_power_reset_reason_clr(reset_reason_clr_msk: u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_mode_set(power_mode: u8) -> u32 {
     let ret: u32;
-    asm!("svc 50",
+    core::arch::asm!("svc 50",
         inout("r0") to_asm(power_mode) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1895,7 +1895,7 @@ pub unsafe fn sd_power_mode_set(power_mode: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_system_off() -> u32 {
     let ret: u32;
-    asm!("svc 51",
+    core::arch::asm!("svc 51",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1916,7 +1916,7 @@ pub unsafe fn sd_power_system_off() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_pof_enable(pof_enable: u8) -> u32 {
     let ret: u32;
-    asm!("svc 54",
+    core::arch::asm!("svc 54",
         inout("r0") to_asm(pof_enable) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1939,7 +1939,7 @@ pub unsafe fn sd_power_pof_enable(pof_enable: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_usbpwrrdy_enable(usbpwrrdy_enable: u8) -> u32 {
     let ret: u32;
-    asm!("svc 77",
+    core::arch::asm!("svc 77",
         inout("r0") to_asm(usbpwrrdy_enable) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1962,7 +1962,7 @@ pub unsafe fn sd_power_usbpwrrdy_enable(usbpwrrdy_enable: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_usbdetected_enable(usbdetected_enable: u8) -> u32 {
     let ret: u32;
-    asm!("svc 78",
+    core::arch::asm!("svc 78",
         inout("r0") to_asm(usbdetected_enable) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -1985,7 +1985,7 @@ pub unsafe fn sd_power_usbdetected_enable(usbdetected_enable: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_usbremoved_enable(usbremoved_enable: u8) -> u32 {
     let ret: u32;
-    asm!("svc 79",
+    core::arch::asm!("svc 79",
         inout("r0") to_asm(usbremoved_enable) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2005,7 +2005,7 @@ pub unsafe fn sd_power_usbremoved_enable(usbremoved_enable: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_usbregstatus_get(usbregstatus: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 80",
+    core::arch::asm!("svc 80",
         inout("r0") to_asm(usbregstatus) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2028,7 +2028,7 @@ pub unsafe fn sd_power_usbregstatus_get(usbregstatus: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_pof_threshold_set(threshold: u8) -> u32 {
     let ret: u32;
-    asm!("svc 55",
+    core::arch::asm!("svc 55",
         inout("r0") to_asm(threshold) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2051,7 +2051,7 @@ pub unsafe fn sd_power_pof_threshold_set(threshold: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_pof_thresholdvddh_set(threshold: u8) -> u32 {
     let ret: u32;
-    asm!("svc 56",
+    core::arch::asm!("svc 56",
         inout("r0") to_asm(threshold) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2070,7 +2070,7 @@ pub unsafe fn sd_power_pof_thresholdvddh_set(threshold: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_ram_power_set(index: u8, ram_powerset: u32) -> u32 {
     let ret: u32;
-    asm!("svc 57",
+    core::arch::asm!("svc 57",
         inout("r0") to_asm(index) => ret,
         inout("r1") to_asm(ram_powerset) => _,
         lateout("r2") _,
@@ -2089,7 +2089,7 @@ pub unsafe fn sd_power_ram_power_set(index: u8, ram_powerset: u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_ram_power_clr(index: u8, ram_powerclr: u32) -> u32 {
     let ret: u32;
-    asm!("svc 58",
+    core::arch::asm!("svc 58",
         inout("r0") to_asm(index) => ret,
         inout("r1") to_asm(ram_powerclr) => _,
         lateout("r2") _,
@@ -2108,7 +2108,7 @@ pub unsafe fn sd_power_ram_power_clr(index: u8, ram_powerclr: u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_ram_power_get(index: u8, p_ram_power: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 59",
+    core::arch::asm!("svc 59",
         inout("r0") to_asm(index) => ret,
         inout("r1") to_asm(p_ram_power) => _,
         lateout("r2") _,
@@ -2127,7 +2127,7 @@ pub unsafe fn sd_power_ram_power_get(index: u8, p_ram_power: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_gpregret_set(gpregret_id: u32, gpregret_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 60",
+    core::arch::asm!("svc 60",
         inout("r0") to_asm(gpregret_id) => ret,
         inout("r1") to_asm(gpregret_msk) => _,
         lateout("r2") _,
@@ -2146,7 +2146,7 @@ pub unsafe fn sd_power_gpregret_set(gpregret_id: u32, gpregret_msk: u32) -> u32 
 #[inline(always)]
 pub unsafe fn sd_power_gpregret_clr(gpregret_id: u32, gpregret_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 61",
+    core::arch::asm!("svc 61",
         inout("r0") to_asm(gpregret_id) => ret,
         inout("r1") to_asm(gpregret_msk) => _,
         lateout("r2") _,
@@ -2165,7 +2165,7 @@ pub unsafe fn sd_power_gpregret_clr(gpregret_id: u32, gpregret_msk: u32) -> u32 
 #[inline(always)]
 pub unsafe fn sd_power_gpregret_get(gpregret_id: u32, p_gpregret: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 62",
+    core::arch::asm!("svc 62",
         inout("r0") to_asm(gpregret_id) => ret,
         inout("r1") to_asm(p_gpregret) => _,
         lateout("r2") _,
@@ -2184,7 +2184,7 @@ pub unsafe fn sd_power_gpregret_get(gpregret_id: u32, p_gpregret: *mut u32) -> u
 #[inline(always)]
 pub unsafe fn sd_power_dcdc_mode_set(dcdc_mode: u8) -> u32 {
     let ret: u32;
-    asm!("svc 63",
+    core::arch::asm!("svc 63",
         inout("r0") to_asm(dcdc_mode) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2205,7 +2205,7 @@ pub unsafe fn sd_power_dcdc_mode_set(dcdc_mode: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_power_dcdc0_mode_set(dcdc_mode: u8) -> u32 {
     let ret: u32;
-    asm!("svc 64",
+    core::arch::asm!("svc 64",
         inout("r0") to_asm(dcdc_mode) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2227,7 +2227,7 @@ pub unsafe fn sd_power_dcdc0_mode_set(dcdc_mode: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_clock_hfclk_request() -> u32 {
     let ret: u32;
-    asm!("svc 66",
+    core::arch::asm!("svc 66",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2248,7 +2248,7 @@ pub unsafe fn sd_clock_hfclk_request() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_clock_hfclk_release() -> u32 {
     let ret: u32;
-    asm!("svc 67",
+    core::arch::asm!("svc 67",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2269,7 +2269,7 @@ pub unsafe fn sd_clock_hfclk_release() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_clock_hfclk_is_running(p_is_running: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 68",
+    core::arch::asm!("svc 68",
         inout("r0") to_asm(p_is_running) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2307,7 +2307,7 @@ pub unsafe fn sd_clock_hfclk_is_running(p_is_running: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_app_evt_wait() -> u32 {
     let ret: u32;
-    asm!("svc 65",
+    core::arch::asm!("svc 65",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2325,7 +2325,7 @@ pub unsafe fn sd_app_evt_wait() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_channel_enable_get(p_channel_enable: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 32",
+    core::arch::asm!("svc 32",
         inout("r0") to_asm(p_channel_enable) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2343,7 +2343,7 @@ pub unsafe fn sd_ppi_channel_enable_get(p_channel_enable: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_channel_enable_set(channel_enable_set_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 33",
+    core::arch::asm!("svc 33",
         inout("r0") to_asm(channel_enable_set_msk) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2361,7 +2361,7 @@ pub unsafe fn sd_ppi_channel_enable_set(channel_enable_set_msk: u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_channel_enable_clr(channel_enable_clr_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 34",
+    core::arch::asm!("svc 34",
         inout("r0") to_asm(channel_enable_clr_msk) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2386,7 +2386,7 @@ pub unsafe fn sd_ppi_channel_assign(
     task_endpoint: *const self::c_void,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 35",
+    core::arch::asm!("svc 35",
         inout("r0") to_asm(channel_num) => ret,
         inout("r1") to_asm(evt_endpoint) => _,
         inout("r2") to_asm(task_endpoint) => _,
@@ -2405,7 +2405,7 @@ pub unsafe fn sd_ppi_channel_assign(
 #[inline(always)]
 pub unsafe fn sd_ppi_group_task_enable(group_num: u8) -> u32 {
     let ret: u32;
-    asm!("svc 36",
+    core::arch::asm!("svc 36",
         inout("r0") to_asm(group_num) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2424,7 +2424,7 @@ pub unsafe fn sd_ppi_group_task_enable(group_num: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_group_task_disable(group_num: u8) -> u32 {
     let ret: u32;
-    asm!("svc 37",
+    core::arch::asm!("svc 37",
         inout("r0") to_asm(group_num) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2444,7 +2444,7 @@ pub unsafe fn sd_ppi_group_task_disable(group_num: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_group_assign(group_num: u8, channel_msk: u32) -> u32 {
     let ret: u32;
-    asm!("svc 38",
+    core::arch::asm!("svc 38",
         inout("r0") to_asm(group_num) => ret,
         inout("r1") to_asm(channel_msk) => _,
         lateout("r2") _,
@@ -2464,7 +2464,7 @@ pub unsafe fn sd_ppi_group_assign(group_num: u8, channel_msk: u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ppi_group_get(group_num: u8, p_channel_msk: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 39",
+    core::arch::asm!("svc 39",
         inout("r0") to_asm(group_num) => ret,
         inout("r1") to_asm(p_channel_msk) => _,
         lateout("r2") _,
@@ -2505,7 +2505,7 @@ pub unsafe fn sd_ppi_group_get(group_num: u8, p_channel_msk: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_radio_notification_cfg_set(type_: u8, distance: u8) -> u32 {
     let ret: u32;
-    asm!("svc 69",
+    core::arch::asm!("svc 69",
         inout("r0") to_asm(type_) => ret,
         inout("r1") to_asm(distance) => _,
         lateout("r2") _,
@@ -2531,7 +2531,7 @@ pub unsafe fn sd_radio_notification_cfg_set(type_: u8, distance: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ecb_block_encrypt(p_ecb_data: *mut nrf_ecb_hal_data_t) -> u32 {
     let ret: u32;
-    asm!("svc 70",
+    core::arch::asm!("svc 70",
         inout("r0") to_asm(p_ecb_data) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2561,7 +2561,7 @@ pub unsafe fn sd_ecb_blocks_encrypt(
     p_data_blocks: *mut nrf_ecb_hal_data_block_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 71",
+    core::arch::asm!("svc 71",
         inout("r0") to_asm(block_count) => ret,
         inout("r1") to_asm(p_data_blocks) => _,
         lateout("r2") _,
@@ -2582,7 +2582,7 @@ pub unsafe fn sd_ecb_blocks_encrypt(
 #[inline(always)]
 pub unsafe fn sd_evt_get(p_evt_id: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 75",
+    core::arch::asm!("svc 75",
         inout("r0") to_asm(p_evt_id) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2603,7 +2603,7 @@ pub unsafe fn sd_evt_get(p_evt_id: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_temp_get(p_temp: *mut i32) -> u32 {
     let ret: u32;
-    asm!("svc 76",
+    core::arch::asm!("svc 76",
         inout("r0") to_asm(p_temp) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2650,7 +2650,7 @@ pub unsafe fn sd_temp_get(p_temp: *mut i32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_flash_write(p_dst: *mut u32, p_src: *const u32, size: u32) -> u32 {
     let ret: u32;
-    asm!("svc 41",
+    core::arch::asm!("svc 41",
         inout("r0") to_asm(p_dst) => ret,
         inout("r1") to_asm(p_src) => _,
         inout("r2") to_asm(size) => _,
@@ -2691,7 +2691,7 @@ pub unsafe fn sd_flash_write(p_dst: *mut u32, p_src: *const u32, size: u32) -> u
 #[inline(always)]
 pub unsafe fn sd_flash_page_erase(page_number: u32) -> u32 {
     let ret: u32;
-    asm!("svc 40",
+    core::arch::asm!("svc 40",
         inout("r0") to_asm(page_number) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2723,7 +2723,7 @@ pub unsafe fn sd_flash_page_erase(page_number: u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_radio_session_open(p_radio_signal_callback: nrf_radio_signal_callback_t) -> u32 {
     let ret: u32;
-    asm!("svc 72",
+    core::arch::asm!("svc 72",
         inout("r0") to_asm(p_radio_signal_callback) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2746,7 +2746,7 @@ pub unsafe fn sd_radio_session_open(p_radio_signal_callback: nrf_radio_signal_ca
 #[inline(always)]
 pub unsafe fn sd_radio_session_close() -> u32 {
     let ret: u32;
-    asm!("svc 73",
+    core::arch::asm!("svc 73",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2793,7 +2793,7 @@ pub unsafe fn sd_radio_session_close() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_radio_request(p_request: *const nrf_radio_request_t) -> u32 {
     let ret: u32;
-    asm!("svc 74",
+    core::arch::asm!("svc 74",
         inout("r0") to_asm(p_request) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -2824,7 +2824,7 @@ pub unsafe fn sd_radio_request(p_request: *const nrf_radio_request_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_protected_register_write(p_register: *mut u32, value: u32) -> u32 {
     let ret: u32;
-    asm!("svc 43",
+    core::arch::asm!("svc 43",
         inout("r0") to_asm(p_register) => ret,
         inout("r1") to_asm(value) => _,
         lateout("r2") _,
@@ -2994,7 +2994,7 @@ pub unsafe fn sd_softdevice_enable(
     fault_handler: nrf_fault_handler_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 16",
+    core::arch::asm!("svc 16",
         inout("r0") to_asm(p_clock_lf_cfg) => ret,
         inout("r1") to_asm(fault_handler) => _,
         lateout("r2") _,
@@ -3019,7 +3019,7 @@ pub unsafe fn sd_softdevice_enable(
 #[inline(always)]
 pub unsafe fn sd_softdevice_disable() -> u32 {
     let ret: u32;
-    asm!("svc 17",
+    core::arch::asm!("svc 17",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -3037,7 +3037,7 @@ pub unsafe fn sd_softdevice_disable() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_softdevice_is_enabled(p_softdevice_enabled: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 18",
+    core::arch::asm!("svc 18",
         inout("r0") to_asm(p_softdevice_enabled) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -3057,7 +3057,7 @@ pub unsafe fn sd_softdevice_is_enabled(p_softdevice_enabled: *mut u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_softdevice_vector_table_base_set(address: u32) -> u32 {
     let ret: u32;
-    asm!("svc 19",
+    core::arch::asm!("svc 19",
         inout("r0") to_asm(address) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -3885,7 +3885,7 @@ fn bindgen_test_layout_sd_mbr_command_t() {
 #[inline(always)]
 pub unsafe fn sd_mbr_command(param: *mut sd_mbr_command_t) -> u32 {
     let ret: u32;
-    asm!("svc 24",
+    core::arch::asm!("svc 24",
         inout("r0") to_asm(param) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -9135,7 +9135,7 @@ fn bindgen_test_layout_ble_gap_conn_event_trigger_t() {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_addr_set(p_addr: *const ble_gap_addr_t) -> u32 {
     let ret: u32;
-    asm!("svc 108",
+    core::arch::asm!("svc 108",
         inout("r0") to_asm(p_addr) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -9157,7 +9157,7 @@ pub unsafe fn sd_ble_gap_addr_set(p_addr: *const ble_gap_addr_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_addr_get(p_addr: *mut ble_gap_addr_t) -> u32 {
     let ret: u32;
-    asm!("svc 109",
+    core::arch::asm!("svc 109",
         inout("r0") to_asm(p_addr) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -9185,7 +9185,7 @@ pub unsafe fn sd_ble_gap_addr_get(p_addr: *mut ble_gap_addr_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_adv_addr_get(adv_handle: u8, p_addr: *mut ble_gap_addr_t) -> u32 {
     let ret: u32;
-    asm!("svc 147",
+    core::arch::asm!("svc 147",
         inout("r0") to_asm(adv_handle) => ret,
         inout("r1") to_asm(p_addr) => _,
         lateout("r2") _,
@@ -9220,7 +9220,7 @@ pub unsafe fn sd_ble_gap_adv_addr_get(adv_handle: u8, p_addr: *mut ble_gap_addr_
 #[inline(always)]
 pub unsafe fn sd_ble_gap_whitelist_set(pp_wl_addrs: *const *const ble_gap_addr_t, len: u8) -> u32 {
     let ret: u32;
-    asm!("svc 110",
+    core::arch::asm!("svc 110",
         inout("r0") to_asm(pp_wl_addrs) => ret,
         inout("r1") to_asm(len) => _,
         lateout("r2") _,
@@ -9264,7 +9264,7 @@ pub unsafe fn sd_ble_gap_device_identities_set(
     len: u8,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 111",
+    core::arch::asm!("svc 111",
         inout("r0") to_asm(pp_id_keys) => ret,
         inout("r1") to_asm(pp_local_irks) => _,
         inout("r2") to_asm(len) => _,
@@ -9301,7 +9301,7 @@ pub unsafe fn sd_ble_gap_device_identities_set(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_privacy_set(p_privacy_params: *const ble_gap_privacy_params_t) -> u32 {
     let ret: u32;
-    asm!("svc 112",
+    core::arch::asm!("svc 112",
         inout("r0") to_asm(p_privacy_params) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -9324,7 +9324,7 @@ pub unsafe fn sd_ble_gap_privacy_set(p_privacy_params: *const ble_gap_privacy_pa
 #[inline(always)]
 pub unsafe fn sd_ble_gap_privacy_get(p_privacy_params: *mut ble_gap_privacy_params_t) -> u32 {
     let ret: u32;
-    asm!("svc 113",
+    core::arch::asm!("svc 113",
         inout("r0") to_asm(p_privacy_params) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -9384,7 +9384,7 @@ pub unsafe fn sd_ble_gap_adv_set_configure(
     p_adv_params: *const ble_gap_adv_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 114",
+    core::arch::asm!("svc 114",
         inout("r0") to_asm(p_adv_handle) => ret,
         inout("r1") to_asm(p_adv_data) => _,
         inout("r2") to_asm(p_adv_params) => _,
@@ -9439,7 +9439,7 @@ pub unsafe fn sd_ble_gap_adv_set_configure(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_adv_start(adv_handle: u8, conn_cfg_tag: u8) -> u32 {
     let ret: u32;
-    asm!("svc 115",
+    core::arch::asm!("svc 115",
         inout("r0") to_asm(adv_handle) => ret,
         inout("r1") to_asm(conn_cfg_tag) => _,
         lateout("r2") _,
@@ -9464,7 +9464,7 @@ pub unsafe fn sd_ble_gap_adv_start(adv_handle: u8, conn_cfg_tag: u8) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_adv_stop(adv_handle: u8) -> u32 {
     let ret: u32;
-    asm!("svc 116",
+    core::arch::asm!("svc 116",
         inout("r0") to_asm(adv_handle) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -9513,7 +9513,7 @@ pub unsafe fn sd_ble_gap_conn_param_update(
     p_conn_params: *const ble_gap_conn_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 117",
+    core::arch::asm!("svc 117",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_conn_params) => _,
         lateout("r2") _,
@@ -9546,7 +9546,7 @@ pub unsafe fn sd_ble_gap_conn_param_update(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_disconnect(conn_handle: u16, hci_status_code: u8) -> u32 {
     let ret: u32;
-    asm!("svc 118",
+    core::arch::asm!("svc 118",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(hci_status_code) => _,
         lateout("r2") _,
@@ -9580,7 +9580,7 @@ pub unsafe fn sd_ble_gap_disconnect(conn_handle: u16, hci_status_code: u8) -> u3
 #[inline(always)]
 pub unsafe fn sd_ble_gap_tx_power_set(role: u8, handle: u16, tx_power: i8) -> u32 {
     let ret: u32;
-    asm!("svc 119",
+    core::arch::asm!("svc 119",
         inout("r0") to_asm(role) => ret,
         inout("r1") to_asm(handle) => _,
         inout("r2") to_asm(tx_power) => _,
@@ -9599,7 +9599,7 @@ pub unsafe fn sd_ble_gap_tx_power_set(role: u8, handle: u16, tx_power: i8) -> u3
 #[inline(always)]
 pub unsafe fn sd_ble_gap_appearance_set(appearance: u16) -> u32 {
     let ret: u32;
-    asm!("svc 120",
+    core::arch::asm!("svc 120",
         inout("r0") to_asm(appearance) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -9618,7 +9618,7 @@ pub unsafe fn sd_ble_gap_appearance_set(appearance: u16) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_appearance_get(p_appearance: *mut u16) -> u32 {
     let ret: u32;
-    asm!("svc 121",
+    core::arch::asm!("svc 121",
         inout("r0") to_asm(p_appearance) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -9640,7 +9640,7 @@ pub unsafe fn sd_ble_gap_appearance_get(p_appearance: *mut u16) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_ppcp_set(p_conn_params: *const ble_gap_conn_params_t) -> u32 {
     let ret: u32;
-    asm!("svc 122",
+    core::arch::asm!("svc 122",
         inout("r0") to_asm(p_conn_params) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -9661,7 +9661,7 @@ pub unsafe fn sd_ble_gap_ppcp_set(p_conn_params: *const ble_gap_conn_params_t) -
 #[inline(always)]
 pub unsafe fn sd_ble_gap_ppcp_get(p_conn_params: *mut ble_gap_conn_params_t) -> u32 {
     let ret: u32;
-    asm!("svc 123",
+    core::arch::asm!("svc 123",
         inout("r0") to_asm(p_conn_params) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -9692,7 +9692,7 @@ pub unsafe fn sd_ble_gap_device_name_set(
     len: u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 124",
+    core::arch::asm!("svc 124",
         inout("r0") to_asm(p_write_perm) => ret,
         inout("r1") to_asm(p_dev_name) => _,
         inout("r2") to_asm(len) => _,
@@ -9718,7 +9718,7 @@ pub unsafe fn sd_ble_gap_device_name_set(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_device_name_get(p_dev_name: *mut u8, p_len: *mut u16) -> u32 {
     let ret: u32;
-    asm!("svc 125",
+    core::arch::asm!("svc 125",
         inout("r0") to_asm(p_dev_name) => ret,
         inout("r1") to_asm(p_len) => _,
         lateout("r2") _,
@@ -9786,7 +9786,7 @@ pub unsafe fn sd_ble_gap_authenticate(
     p_sec_params: *const ble_gap_sec_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 126",
+    core::arch::asm!("svc 126",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_sec_params) => _,
         lateout("r2") _,
@@ -9863,7 +9863,7 @@ pub unsafe fn sd_ble_gap_sec_params_reply(
     p_sec_keyset: *const ble_gap_sec_keyset_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 127",
+    core::arch::asm!("svc 127",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(sec_status) => _,
         inout("r2") to_asm(p_sec_params) => _,
@@ -9906,7 +9906,7 @@ pub unsafe fn sd_ble_gap_sec_params_reply(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_auth_key_reply(conn_handle: u16, key_type: u8, p_key: *const u8) -> u32 {
     let ret: u32;
-    asm!("svc 128",
+    core::arch::asm!("svc 128",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(key_type) => _,
         inout("r2") to_asm(p_key) => _,
@@ -9954,7 +9954,7 @@ pub unsafe fn sd_ble_gap_lesc_dhkey_reply(
     p_dhkey: *const ble_gap_lesc_dhkey_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 129",
+    core::arch::asm!("svc 129",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_dhkey) => _,
         lateout("r2") _,
@@ -9985,7 +9985,7 @@ pub unsafe fn sd_ble_gap_lesc_dhkey_reply(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_keypress_notify(conn_handle: u16, kp_not: u8) -> u32 {
     let ret: u32;
-    asm!("svc 130",
+    core::arch::asm!("svc 130",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(kp_not) => _,
         lateout("r2") _,
@@ -10019,7 +10019,7 @@ pub unsafe fn sd_ble_gap_lesc_oob_data_get(
     p_oobd_own: *mut ble_gap_lesc_oob_data_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 131",
+    core::arch::asm!("svc 131",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_pk_own) => _,
         inout("r2") to_asm(p_oobd_own) => _,
@@ -10065,7 +10065,7 @@ pub unsafe fn sd_ble_gap_lesc_oob_data_set(
     p_oobd_peer: *const ble_gap_lesc_oob_data_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 132",
+    core::arch::asm!("svc 132",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_oobd_own) => _,
         inout("r2") to_asm(p_oobd_peer) => _,
@@ -10107,7 +10107,7 @@ pub unsafe fn sd_ble_gap_encrypt(
     p_enc_info: *const ble_gap_enc_info_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 133",
+    core::arch::asm!("svc 133",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_master_id) => _,
         inout("r2") to_asm(p_enc_info) => _,
@@ -10147,7 +10147,7 @@ pub unsafe fn sd_ble_gap_sec_info_reply(
     p_sign_info: *const ble_gap_sign_info_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 134",
+    core::arch::asm!("svc 134",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_enc_info) => _,
         inout("r2") to_asm(p_id_info) => _,
@@ -10171,7 +10171,7 @@ pub unsafe fn sd_ble_gap_conn_sec_get(
     p_conn_sec: *mut ble_gap_conn_sec_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 135",
+    core::arch::asm!("svc 135",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_conn_sec) => _,
         lateout("r2") _,
@@ -10206,7 +10206,7 @@ pub unsafe fn sd_ble_gap_conn_sec_get(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_rssi_start(conn_handle: u16, threshold_dbm: u8, skip_count: u8) -> u32 {
     let ret: u32;
-    asm!("svc 136",
+    core::arch::asm!("svc 136",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(threshold_dbm) => _,
         inout("r2") to_asm(skip_count) => _,
@@ -10234,7 +10234,7 @@ pub unsafe fn sd_ble_gap_rssi_start(conn_handle: u16, threshold_dbm: u8, skip_co
 #[inline(always)]
 pub unsafe fn sd_ble_gap_rssi_stop(conn_handle: u16) -> u32 {
     let ret: u32;
-    asm!("svc 137",
+    core::arch::asm!("svc 137",
         inout("r0") to_asm(conn_handle) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -10265,7 +10265,7 @@ pub unsafe fn sd_ble_gap_rssi_stop(conn_handle: u16) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_rssi_get(conn_handle: u16, p_rssi: *mut i8, p_ch_index: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 142",
+    core::arch::asm!("svc 142",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_rssi) => _,
         inout("r2") to_asm(p_ch_index) => _,
@@ -10330,7 +10330,7 @@ pub unsafe fn sd_ble_gap_scan_start(
     p_adv_report_buffer: *const ble_data_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 138",
+    core::arch::asm!("svc 138",
         inout("r0") to_asm(p_scan_params) => ret,
         inout("r1") to_asm(p_adv_report_buffer) => _,
         lateout("r2") _,
@@ -10354,7 +10354,7 @@ pub unsafe fn sd_ble_gap_scan_start(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_scan_stop() -> u32 {
     let ret: u32;
-    asm!("svc 139",
+    core::arch::asm!("svc 139",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -10414,7 +10414,7 @@ pub unsafe fn sd_ble_gap_connect(
     conn_cfg_tag: u8,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 140",
+    core::arch::asm!("svc 140",
         inout("r0") to_asm(p_peer_addr) => ret,
         inout("r1") to_asm(p_scan_params) => _,
         inout("r2") to_asm(p_conn_params) => _,
@@ -10436,7 +10436,7 @@ pub unsafe fn sd_ble_gap_connect(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_connect_cancel() -> u32 {
     let ret: u32;
-    asm!("svc 141",
+    core::arch::asm!("svc 141",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -10501,7 +10501,7 @@ pub unsafe fn sd_ble_gap_connect_cancel() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_phy_update(conn_handle: u16, p_gap_phys: *const ble_gap_phys_t) -> u32 {
     let ret: u32;
-    asm!("svc 143",
+    core::arch::asm!("svc 143",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_gap_phys) => _,
         lateout("r2") _,
@@ -10552,7 +10552,7 @@ pub unsafe fn sd_ble_gap_data_length_update(
     p_dl_limitation: *mut ble_gap_data_length_limitation_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 144",
+    core::arch::asm!("svc 144",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_dl_params) => _,
         inout("r2") to_asm(p_dl_limitation) => _,
@@ -10594,7 +10594,7 @@ pub unsafe fn sd_ble_gap_data_length_update(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_qos_channel_survey_start(interval_us: u32) -> u32 {
     let ret: u32;
-    asm!("svc 145",
+    core::arch::asm!("svc 145",
         inout("r0") to_asm(interval_us) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -10614,7 +10614,7 @@ pub unsafe fn sd_ble_gap_qos_channel_survey_start(interval_us: u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_qos_channel_survey_stop() -> u32 {
     let ret: u32;
-    asm!("svc 146",
+    core::arch::asm!("svc 146",
         lateout("r0") ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -10647,7 +10647,7 @@ pub unsafe fn sd_ble_gap_qos_channel_survey_stop() -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_gap_next_conn_evt_counter_get(conn_handle: u16, p_counter: *mut u16) -> u32 {
     let ret: u32;
-    asm!("svc 148",
+    core::arch::asm!("svc 148",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_counter) => _,
         lateout("r2") _,
@@ -10681,7 +10681,7 @@ pub unsafe fn sd_ble_gap_conn_evt_trigger_start(
     p_params: *const ble_gap_conn_event_trigger_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 149",
+    core::arch::asm!("svc 149",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_params) => _,
         lateout("r2") _,
@@ -10701,7 +10701,7 @@ pub unsafe fn sd_ble_gap_conn_evt_trigger_start(
 #[inline(always)]
 pub unsafe fn sd_ble_gap_conn_evt_trigger_stop(conn_handle: u16) -> u32 {
     let ret: u32;
-    asm!("svc 150",
+    core::arch::asm!("svc 150",
         inout("r0") to_asm(conn_handle) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -11562,7 +11562,7 @@ pub unsafe fn sd_ble_l2cap_ch_setup(
     p_params: *const ble_l2cap_ch_setup_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 184",
+    core::arch::asm!("svc 184",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_local_cid) => _,
         inout("r2") to_asm(p_params) => _,
@@ -11595,7 +11595,7 @@ pub unsafe fn sd_ble_l2cap_ch_setup(
 #[inline(always)]
 pub unsafe fn sd_ble_l2cap_ch_release(conn_handle: u16, local_cid: u16) -> u32 {
     let ret: u32;
-    asm!("svc 185",
+    core::arch::asm!("svc 185",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(local_cid) => _,
         lateout("r2") _,
@@ -11643,7 +11643,7 @@ pub unsafe fn sd_ble_l2cap_ch_rx(
     p_sdu_buf: *const ble_data_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 186",
+    core::arch::asm!("svc 186",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(local_cid) => _,
         inout("r2") to_asm(p_sdu_buf) => _,
@@ -11702,7 +11702,7 @@ pub unsafe fn sd_ble_l2cap_ch_tx(
     p_sdu_buf: *const ble_data_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 187",
+    core::arch::asm!("svc 187",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(local_cid) => _,
         inout("r2") to_asm(p_sdu_buf) => _,
@@ -11761,7 +11761,7 @@ pub unsafe fn sd_ble_l2cap_ch_flow_control(
     p_credits: *mut u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 188",
+    core::arch::asm!("svc 188",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(local_cid) => _,
         inout("r2") to_asm(credits) => _,
@@ -13426,7 +13426,7 @@ pub unsafe fn sd_ble_gattc_primary_services_discover(
     p_srvc_uuid: *const ble_uuid_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 155",
+    core::arch::asm!("svc 155",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(start_handle) => _,
         inout("r2") to_asm(p_srvc_uuid) => _,
@@ -13465,7 +13465,7 @@ pub unsafe fn sd_ble_gattc_relationships_discover(
     p_handle_range: *const ble_gattc_handle_range_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 156",
+    core::arch::asm!("svc 156",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_handle_range) => _,
         lateout("r2") _,
@@ -13506,7 +13506,7 @@ pub unsafe fn sd_ble_gattc_characteristics_discover(
     p_handle_range: *const ble_gattc_handle_range_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 157",
+    core::arch::asm!("svc 157",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_handle_range) => _,
         lateout("r2") _,
@@ -13544,7 +13544,7 @@ pub unsafe fn sd_ble_gattc_descriptors_discover(
     p_handle_range: *const ble_gattc_handle_range_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 158",
+    core::arch::asm!("svc 158",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_handle_range) => _,
         lateout("r2") _,
@@ -13584,7 +13584,7 @@ pub unsafe fn sd_ble_gattc_char_value_by_uuid_read(
     p_handle_range: *const ble_gattc_handle_range_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 160",
+    core::arch::asm!("svc 160",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_uuid) => _,
         inout("r2") to_asm(p_handle_range) => _,
@@ -13620,7 +13620,7 @@ pub unsafe fn sd_ble_gattc_char_value_by_uuid_read(
 #[inline(always)]
 pub unsafe fn sd_ble_gattc_read(conn_handle: u16, handle: u16, offset: u16) -> u32 {
     let ret: u32;
-    asm!("svc 161",
+    core::arch::asm!("svc 161",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(handle) => _,
         inout("r2") to_asm(offset) => _,
@@ -13659,7 +13659,7 @@ pub unsafe fn sd_ble_gattc_char_values_read(
     handle_count: u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 162",
+    core::arch::asm!("svc 162",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_handles) => _,
         inout("r2") to_asm(handle_count) => _,
@@ -13718,7 +13718,7 @@ pub unsafe fn sd_ble_gattc_write(
     p_write_params: *const ble_gattc_write_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 163",
+    core::arch::asm!("svc 163",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_write_params) => _,
         lateout("r2") _,
@@ -13745,7 +13745,7 @@ pub unsafe fn sd_ble_gattc_write(
 #[inline(always)]
 pub unsafe fn sd_ble_gattc_hv_confirm(conn_handle: u16, handle: u16) -> u32 {
     let ret: u32;
-    asm!("svc 164",
+    core::arch::asm!("svc 164",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(handle) => _,
         lateout("r2") _,
@@ -13776,7 +13776,7 @@ pub unsafe fn sd_ble_gattc_attr_info_discover(
     p_handle_range: *const ble_gattc_handle_range_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 159",
+    core::arch::asm!("svc 159",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_handle_range) => _,
         lateout("r2") _,
@@ -13819,7 +13819,7 @@ pub unsafe fn sd_ble_gattc_attr_info_discover(
 #[inline(always)]
 pub unsafe fn sd_ble_gattc_exchange_mtu_request(conn_handle: u16, client_rx_mtu: u16) -> u32 {
     let ret: u32;
-    asm!("svc 165",
+    core::arch::asm!("svc 165",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(client_rx_mtu) => _,
         lateout("r2") _,
@@ -15500,7 +15500,7 @@ pub unsafe fn sd_ble_gatts_service_add(
     p_handle: *mut u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 168",
+    core::arch::asm!("svc 168",
         inout("r0") to_asm(type_) => ret,
         inout("r1") to_asm(p_uuid) => _,
         inout("r2") to_asm(p_handle) => _,
@@ -15539,7 +15539,7 @@ pub unsafe fn sd_ble_gatts_include_add(
     p_include_handle: *mut u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 169",
+    core::arch::asm!("svc 169",
         inout("r0") to_asm(service_handle) => ret,
         inout("r1") to_asm(inc_srvc_handle) => _,
         inout("r2") to_asm(p_include_handle) => _,
@@ -15582,7 +15582,7 @@ pub unsafe fn sd_ble_gatts_characteristic_add(
     p_handles: *mut ble_gatts_char_handles_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 170",
+    core::arch::asm!("svc 170",
         inout("r0") to_asm(service_handle) => ret,
         inout("r1") to_asm(p_char_md) => _,
         inout("r2") to_asm(p_attr_char_value) => _,
@@ -15618,7 +15618,7 @@ pub unsafe fn sd_ble_gatts_descriptor_add(
     p_handle: *mut u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 171",
+    core::arch::asm!("svc 171",
         inout("r0") to_asm(char_handle) => ret,
         inout("r1") to_asm(p_attr) => _,
         inout("r2") to_asm(p_handle) => _,
@@ -15655,7 +15655,7 @@ pub unsafe fn sd_ble_gatts_value_set(
     p_value: *mut ble_gatts_value_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 172",
+    core::arch::asm!("svc 172",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(handle) => _,
         inout("r2") to_asm(p_value) => _,
@@ -15693,7 +15693,7 @@ pub unsafe fn sd_ble_gatts_value_get(
     p_value: *mut ble_gatts_value_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 173",
+    core::arch::asm!("svc 173",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(handle) => _,
         inout("r2") to_asm(p_value) => _,
@@ -15771,7 +15771,7 @@ pub unsafe fn sd_ble_gatts_hvx(
     p_hvx_params: *const ble_gatts_hvx_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 174",
+    core::arch::asm!("svc 174",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_hvx_params) => _,
         lateout("r2") _,
@@ -15821,7 +15821,7 @@ pub unsafe fn sd_ble_gatts_service_changed(
     end_handle: u16,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 175",
+    core::arch::asm!("svc 175",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(start_handle) => _,
         inout("r2") to_asm(end_handle) => _,
@@ -15867,7 +15867,7 @@ pub unsafe fn sd_ble_gatts_rw_authorize_reply(
     p_rw_authorize_reply_params: *const ble_gatts_rw_authorize_reply_params_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 176",
+    core::arch::asm!("svc 176",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_rw_authorize_reply_params) => _,
         lateout("r2") _,
@@ -15925,7 +15925,7 @@ pub unsafe fn sd_ble_gatts_sys_attr_set(
     flags: u32,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 177",
+    core::arch::asm!("svc 177",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_sys_attr_data) => _,
         inout("r2") to_asm(len) => _,
@@ -15972,7 +15972,7 @@ pub unsafe fn sd_ble_gatts_sys_attr_get(
     flags: u32,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 178",
+    core::arch::asm!("svc 178",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_sys_attr_data) => _,
         inout("r2") to_asm(p_len) => _,
@@ -15991,7 +15991,7 @@ pub unsafe fn sd_ble_gatts_sys_attr_get(
 #[inline(always)]
 pub unsafe fn sd_ble_gatts_initial_user_handle_get(p_handle: *mut u16) -> u32 {
     let ret: u32;
-    asm!("svc 179",
+    core::arch::asm!("svc 179",
         inout("r0") to_asm(p_handle) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -16018,7 +16018,7 @@ pub unsafe fn sd_ble_gatts_attr_get(
     p_md: *mut ble_gatts_attr_md_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 180",
+    core::arch::asm!("svc 180",
         inout("r0") to_asm(handle) => ret,
         inout("r1") to_asm(p_uuid) => _,
         inout("r2") to_asm(p_md) => _,
@@ -16058,7 +16058,7 @@ pub unsafe fn sd_ble_gatts_attr_get(
 #[inline(always)]
 pub unsafe fn sd_ble_gatts_exchange_mtu_reply(conn_handle: u16, server_rx_mtu: u16) -> u32 {
     let ret: u32;
-    asm!("svc 181",
+    core::arch::asm!("svc 181",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(server_rx_mtu) => _,
         lateout("r2") _,
@@ -17264,7 +17264,7 @@ fn bindgen_test_layout_ble_cfg_t() {
 #[inline(always)]
 pub unsafe fn sd_ble_enable(p_app_ram_base: *mut u32) -> u32 {
     let ret: u32;
-    asm!("svc 96",
+    core::arch::asm!("svc 96",
         inout("r0") to_asm(p_app_ram_base) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -17310,7 +17310,7 @@ pub unsafe fn sd_ble_enable(p_app_ram_base: *mut u32) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_cfg_set(cfg_id: u32, p_cfg: *const ble_cfg_t, app_ram_base: u32) -> u32 {
     let ret: u32;
-    asm!("svc 105",
+    core::arch::asm!("svc 105",
         inout("r0") to_asm(cfg_id) => ret,
         inout("r1") to_asm(p_cfg) => _,
         inout("r2") to_asm(app_ram_base) => _,
@@ -17358,7 +17358,7 @@ pub unsafe fn sd_ble_cfg_set(cfg_id: u32, p_cfg: *const ble_cfg_t, app_ram_base:
 #[inline(always)]
 pub unsafe fn sd_ble_evt_get(p_dest: *mut u8, p_len: *mut u16) -> u32 {
     let ret: u32;
-    asm!("svc 97",
+    core::arch::asm!("svc 97",
         inout("r0") to_asm(p_dest) => ret,
         inout("r1") to_asm(p_len) => _,
         lateout("r2") _,
@@ -17396,7 +17396,7 @@ pub unsafe fn sd_ble_evt_get(p_dest: *mut u8, p_len: *mut u16) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_uuid_vs_add(p_vs_uuid: *const ble_uuid128_t, p_uuid_type: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 98",
+    core::arch::asm!("svc 98",
         inout("r0") to_asm(p_vs_uuid) => ret,
         inout("r1") to_asm(p_uuid_type) => _,
         lateout("r2") _,
@@ -17426,7 +17426,7 @@ pub unsafe fn sd_ble_uuid_vs_add(p_vs_uuid: *const ble_uuid128_t, p_uuid_type: *
 #[inline(always)]
 pub unsafe fn sd_ble_uuid_vs_remove(p_uuid_type: *mut u8) -> u32 {
     let ret: u32;
-    asm!("svc 106",
+    core::arch::asm!("svc 106",
         inout("r0") to_asm(p_uuid_type) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -17460,7 +17460,7 @@ pub unsafe fn sd_ble_uuid_decode(
     p_uuid: *mut ble_uuid_t,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 99",
+    core::arch::asm!("svc 99",
         inout("r0") to_asm(uuid_le_len) => ret,
         inout("r1") to_asm(p_uuid_le) => _,
         inout("r2") to_asm(p_uuid) => _,
@@ -17488,7 +17488,7 @@ pub unsafe fn sd_ble_uuid_encode(
     p_uuid_le: *mut u8,
 ) -> u32 {
     let ret: u32;
-    asm!("svc 100",
+    core::arch::asm!("svc 100",
         inout("r0") to_asm(p_uuid) => ret,
         inout("r1") to_asm(p_uuid_le_len) => _,
         inout("r2") to_asm(p_uuid_le) => _,
@@ -17510,7 +17510,7 @@ pub unsafe fn sd_ble_uuid_encode(
 #[inline(always)]
 pub unsafe fn sd_ble_version_get(p_version: *mut ble_version_t) -> u32 {
     let ret: u32;
-    asm!("svc 101",
+    core::arch::asm!("svc 101",
         inout("r0") to_asm(p_version) => ret,
         lateout("r1") _,
         lateout("r2") _,
@@ -17545,7 +17545,7 @@ pub unsafe fn sd_ble_version_get(p_version: *mut ble_version_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_user_mem_reply(conn_handle: u16, p_block: *const ble_user_mem_block_t) -> u32 {
     let ret: u32;
-    asm!("svc 102",
+    core::arch::asm!("svc 102",
         inout("r0") to_asm(conn_handle) => ret,
         inout("r1") to_asm(p_block) => _,
         lateout("r2") _,
@@ -17571,7 +17571,7 @@ pub unsafe fn sd_ble_user_mem_reply(conn_handle: u16, p_block: *const ble_user_m
 #[inline(always)]
 pub unsafe fn sd_ble_opt_set(opt_id: u32, p_opt: *const ble_opt_t) -> u32 {
     let ret: u32;
-    asm!("svc 103",
+    core::arch::asm!("svc 103",
         inout("r0") to_asm(opt_id) => ret,
         inout("r1") to_asm(p_opt) => _,
         lateout("r2") _,
@@ -17599,7 +17599,7 @@ pub unsafe fn sd_ble_opt_set(opt_id: u32, p_opt: *const ble_opt_t) -> u32 {
 #[inline(always)]
 pub unsafe fn sd_ble_opt_get(opt_id: u32, p_opt: *mut ble_opt_t) -> u32 {
     let ret: u32;
-    asm!("svc 104",
+    core::arch::asm!("svc 104",
         inout("r0") to_asm(opt_id) => ret,
         inout("r1") to_asm(p_opt) => _,
         lateout("r2") _,

--- a/nrf-softdevice-s140/src/lib.rs
+++ b/nrf-softdevice-s140/src/lib.rs
@@ -3,7 +3,6 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_snake_case)]
 #![allow(dead_code)]
-#![feature(asm)]
 
 mod bindings;
 

--- a/nrf-softdevice/src/critical_section_impl.rs
+++ b/nrf-softdevice/src/critical_section_impl.rs
@@ -1,4 +1,5 @@
 use crate::pac::{Interrupt, NVIC};
+use core::arch::asm;
 use core::sync::atomic::{compiler_fence, AtomicBool, Ordering};
 
 #[cfg(any(feature = "nrf52810", feature = "nrf52811"))]

--- a/nrf-softdevice/src/lib.rs
+++ b/nrf-softdevice/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![feature(asm)]
 #![feature(generic_associated_types)]
 #![feature(type_alias_impl_trait)]
 #![feature(const_fn_trait_bound)]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 # Before upgrading check that everything is available on all tier1 targets here:
 # https://rust-lang.github.io/rustup-components-history
 [toolchain]
-channel = "nightly-2021-10-16"
+channel = "nightly-2021-12-16"
 components = ["rust-src", "rustfmt"]
 targets = ["thumbv7em-none-eabihf"]


### PR DESCRIPTION
Update the toolchain to match embassy.
I manually replaced `asm!` with `core::arch::asm!` in bindings because regenerating them resulted in a large diff.

EDIT: Build fixed by running `cargo update` to get the latest embassy changes
~~PR as draft because I get some errors when I try to compile the examples now, not sure how those are related to the new toolchain.~~
```
.cargo\git\checkouts\embassy-9312dcb0ed774b29\2718815\embassy-traits\src\delay.rs:4:5
  |
4 |     type DelayFuture<'a>: Future<Output = ()> + 'a;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
  |                                                   |
  |                                                   help: add the required where clause: `where Self: 'a`
  |
  = note: this bound is currently required to ensure that impls have maximum flexibility
  = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
```
