### PR TITLE
Add `Softdevice::run_with_callback()` to receive unhandled `SocEvent`s

### DIFF
--- a/nrf-softdevice/src/softdevice.rs
+++ b/nrf-softdevice/src/softdevice.rs
@@ -323,10 +323,11 @@ impl Softdevice {
         self.run_with_callback(|_| {}).await
     }
 
-    /// Runs the softdevice event handling loop.
+    /// Runs the softdevice event handling loop with a callback for [`SocEvent`]s.
     ///
-    /// It must be called in its own async task after enabling the softdevice
-    /// and before doing any operation. Failure to doing so will cause async operations to never finish.
+    /// It must be called under the same conditions as [`Softdevice::run()`]. This
+    /// version allows the application to provide a callback to receive SoC events
+    /// from the softdevice (other than flash events which are handled by [`Flash`](crate::flash::Flash)).
     pub async fn run_with_callback<F: FnMut(SocEvent)>(&self, f: F) -> ! {
         crate::events::run(f).await
     }

--- a/nrf-softdevice/src/softdevice.rs
+++ b/nrf-softdevice/src/softdevice.rs
@@ -3,9 +3,9 @@ use core::ptr;
 use core::sync::atomic::{AtomicBool, Ordering};
 use embassy::util::Forever;
 
-use crate::pac;
 use crate::raw;
 use crate::RawError;
+use crate::{pac, SocEvent};
 
 unsafe extern "C" fn fault_handler(id: u32, pc: u32, info: u32) {
     match (id, info) {
@@ -320,6 +320,14 @@ impl Softdevice {
     /// It must be called in its own async task after enabling the softdevice
     /// and before doing any operation. Failure to doing so will cause async operations to never finish.
     pub async fn run(&self) -> ! {
-        crate::events::run().await
+        self.run_with_callback(|_| {}).await
+    }
+
+    /// Runs the softdevice event handling loop.
+    ///
+    /// It must be called in its own async task after enabling the softdevice
+    /// and before doing any operation. Failure to doing so will cause async operations to never finish.
+    pub async fn run_with_callback<F: FnMut(SocEvent)>(&self, f: F) -> ! {
+        crate::events::run(f).await
     }
 }


### PR DESCRIPTION
I'd like to be able to handle `SocEvent::UsbPower*` events from my application when using the softdevice. This change adds an alternative run function that takes a callback that will receive any `SocEvent`s that are not handled by `nrf_softdevice` itself.