### PR TITLE
Fix cccd attribute missing

### DIFF
--- a/nrf-softdevice/src/ble/gatt_server.rs
+++ b/nrf-softdevice/src/ble/gatt_server.rs
@@ -182,6 +182,12 @@ where
 
                     server.on_write(params.handle, &v).map(|e| f(e));
                 }
+                raw::BLE_GATTS_EVTS_BLE_GATTS_EVT_SYS_ATTR_MISSING => {
+                    info!("initializing gatt sys att");
+                    let ret =
+                        raw::sd_ble_gatts_sys_attr_set(conn_handle, ::core::ptr::null(), 0, 0);
+                    RawError::convert(ret).err();
+                }
                 _ => {}
             }
             None


### PR DESCRIPTION
See issue #117 .

Since there was already an event listener I simply added a case instead of initializing every cccd at connection time.