### PR TITLE
Lower some log levels.

### DIFF
--- a/nrf-softdevice/src/ble/central.rs
+++ b/nrf-softdevice/src/ble/central.rs
@@ -57,7 +57,7 @@ pub async fn connect(
         return Err(err.into());
     }
 
-    info!("connect started");
+    debug!("connect started");
 
     let conn = CONNECT_PORTAL
         .wait_once(|ble_evt| unsafe {
@@ -186,7 +186,7 @@ where
         }
     });
 
-    info!("Scan started");
+    debug!("Scan started");
     let res = SCAN_PORTAL
         .wait_many(|ble_evt| unsafe {
             match (*ble_evt).header.evt_id as u32 {

--- a/nrf-softdevice/src/ble/gatt_client.rs
+++ b/nrf-softdevice/src/ble/gatt_client.rs
@@ -612,14 +612,14 @@ pub(crate) async fn att_mtu_exchange(conn: &Connection, mtu: u16) -> Result<(), 
     let current_mtu = conn.with_state(|state| state.att_mtu);
 
     if current_mtu >= mtu {
-        info!(
+        debug!(
             "att mtu exchange: want mtu {:?}, already got {:?}. Doing nothing.",
             mtu, current_mtu
         );
         return Ok(());
     }
 
-    info!(
+    debug!(
         "att mtu exchange: want mtu {:?}, got only {:?}, doing exchange...",
         mtu, current_mtu
     );
@@ -643,7 +643,7 @@ pub(crate) async fn att_mtu_exchange(conn: &Connection, mtu: u16) -> Result<(), 
                     };
                     let params = get_union_field(ble_evt, &gattc_evt.params.exchange_mtu_rsp);
                     let mtu = params.server_rx_mtu;
-                    info!("att mtu exchange: got mtu {:?}", mtu);
+                    debug!("att mtu exchange: got mtu {:?}", mtu);
                     conn.with_state(|state| state.att_mtu = mtu);
 
                     Ok(())

--- a/nrf-softdevice/src/ble/gatt_server.rs
+++ b/nrf-softdevice/src/ble/gatt_server.rs
@@ -183,7 +183,7 @@ where
                     server.on_write(params.handle, &v).map(|e| f(e));
                 }
                 raw::BLE_GATTS_EVTS_BLE_GATTS_EVT_SYS_ATTR_MISSING => {
-                    info!("initializing gatt sys att");
+                    debug!("initializing gatt sys att");
                     let ret =
                         raw::sd_ble_gatts_sys_attr_set(conn_handle, ::core::ptr::null(), 0, 0);
                     RawError::convert(ret).err();

--- a/nrf-softdevice/src/ble/l2cap.rs
+++ b/nrf-softdevice/src/ble/l2cap.rs
@@ -22,14 +22,14 @@ fn credit_hack_refill(conn: u16, cid: u16) {
         warn!("sd_ble_l2cap_ch_flow_control credits query err {:?}", err);
         return;
     }
-    info!("sd_ble_l2cap_ch_flow_control credits={=u16:x}", credits);
+    trace!("sd_ble_l2cap_ch_flow_control credits={=u16:x}", credits);
 
     if credits > CREDITS_MIN {
         // Still enough credits, no need to refill.
         return;
     }
 
-    info!("refilling credits");
+    debug!("refilling credits");
 
     let ret = unsafe { raw::sd_ble_l2cap_ch_flow_control(conn, cid, CREDITS_MAX, ptr::null_mut()) };
     if let Err(err) = RawError::convert(ret) {
@@ -194,7 +194,7 @@ impl<P: Packet> L2cap<P> {
             warn!("sd_ble_l2cap_ch_setup err {:?}", err);
             return Err(err.into());
         }
-        info!("cid {:?}", cid);
+        debug!("cid {:?}", cid);
 
         portal(conn_handle)
             .wait_once(|ble_evt| unsafe {

--- a/nrf-softdevice/src/events.rs
+++ b/nrf-softdevice/src/events.rs
@@ -33,7 +33,7 @@ pub enum SocEvent {
 }
 
 fn on_soc_evt<F: FnMut(SocEvent)>(evt: u32, evt_handler: &mut F) {
-    info!("soc evt {:?}", evt);
+    trace!("soc evt {:?}", evt);
 
     match evt {
         raw::NRF_SOC_EVTS_NRF_EVT_FLASH_OPERATION_ERROR => crate::flash::on_flash_error(),


### PR DESCRIPTION
Ideally during normal operation very little things should be logged at `info` level.
Lower them to trace/debug.

As a general rule, I'm setting logs that fire per packet to `trace` and
everything else to `debug`.