### PR TITLE
Update for `embassy-util` split

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ dependencies = [
 [[package]]
 name = "embassy-cortex-m"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=d881f3ad9186cf3279aa1ba27093bad94035c186#d881f3ad9186cf3279aa1ba27093bad94035c186"
+source = "git+https://github.com/embassy-rs/embassy?rev=cb9f0ef5b800ce4a22cde1805e0eb88425f1e07b#cb9f0ef5b800ce4a22cde1805e0eb88425f1e07b"
 dependencies = [
  "atomic-polyfill 1.0.1",
  "cfg-if",
@@ -312,16 +312,16 @@ dependencies = [
  "embassy-executor",
  "embassy-hal-common",
  "embassy-macros",
- "embassy-util",
+ "embassy-sync",
 ]
 
 [[package]]
 name = "embassy-embedded-hal"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=d881f3ad9186cf3279aa1ba27093bad94035c186#d881f3ad9186cf3279aa1ba27093bad94035c186"
+source = "git+https://github.com/embassy-rs/embassy?rev=cb9f0ef5b800ce4a22cde1805e0eb88425f1e07b#cb9f0ef5b800ce4a22cde1805e0eb88425f1e07b"
 dependencies = [
  "defmt",
- "embassy-util",
+ "embassy-sync",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0-alpha.8",
  "embedded-hal-async",
@@ -333,31 +333,35 @@ dependencies = [
 [[package]]
 name = "embassy-executor"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=d881f3ad9186cf3279aa1ba27093bad94035c186#d881f3ad9186cf3279aa1ba27093bad94035c186"
+source = "git+https://github.com/embassy-rs/embassy?rev=cb9f0ef5b800ce4a22cde1805e0eb88425f1e07b#cb9f0ef5b800ce4a22cde1805e0eb88425f1e07b"
 dependencies = [
  "atomic-polyfill 1.0.1",
  "cfg-if",
  "critical-section 1.1.0",
  "defmt",
  "embassy-macros",
- "embedded-hal 0.2.7",
- "embedded-hal-async",
+ "embassy-time",
  "futures-util",
+ "static_cell",
 ]
+
+[[package]]
+name = "embassy-futures"
+version = "0.1.0"
+source = "git+https://github.com/embassy-rs/embassy?rev=cb9f0ef5b800ce4a22cde1805e0eb88425f1e07b#cb9f0ef5b800ce4a22cde1805e0eb88425f1e07b"
 
 [[package]]
 name = "embassy-hal-common"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=d881f3ad9186cf3279aa1ba27093bad94035c186#d881f3ad9186cf3279aa1ba27093bad94035c186"
+source = "git+https://github.com/embassy-rs/embassy?rev=cb9f0ef5b800ce4a22cde1805e0eb88425f1e07b#cb9f0ef5b800ce4a22cde1805e0eb88425f1e07b"
 dependencies = [
- "embassy-util",
  "num-traits",
 ]
 
 [[package]]
 name = "embassy-macros"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=d881f3ad9186cf3279aa1ba27093bad94035c186#d881f3ad9186cf3279aa1ba27093bad94035c186"
+source = "git+https://github.com/embassy-rs/embassy?rev=cb9f0ef5b800ce4a22cde1805e0eb88425f1e07b#cb9f0ef5b800ce4a22cde1805e0eb88425f1e07b"
 dependencies = [
  "darling 0.13.4",
  "proc-macro2",
@@ -368,7 +372,7 @@ dependencies = [
 [[package]]
 name = "embassy-nrf"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=d881f3ad9186cf3279aa1ba27093bad94035c186#d881f3ad9186cf3279aa1ba27093bad94035c186"
+source = "git+https://github.com/embassy-rs/embassy?rev=cb9f0ef5b800ce4a22cde1805e0eb88425f1e07b#cb9f0ef5b800ce4a22cde1805e0eb88425f1e07b"
 dependencies = [
  "cfg-if",
  "cortex-m",
@@ -379,9 +383,9 @@ dependencies = [
  "embassy-embedded-hal",
  "embassy-executor",
  "embassy-hal-common",
- "embassy-macros",
+ "embassy-sync",
+ "embassy-time",
  "embassy-usb",
- "embassy-util",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0-alpha.8",
  "embedded-hal-async",
@@ -395,19 +399,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "embassy-usb"
+name = "embassy-sync"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=d881f3ad9186cf3279aa1ba27093bad94035c186#d881f3ad9186cf3279aa1ba27093bad94035c186"
-dependencies = [
- "defmt",
- "embassy-util",
- "heapless",
-]
-
-[[package]]
-name = "embassy-util"
-version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=d881f3ad9186cf3279aa1ba27093bad94035c186#d881f3ad9186cf3279aa1ba27093bad94035c186"
+source = "git+https://github.com/embassy-rs/embassy?rev=cb9f0ef5b800ce4a22cde1805e0eb88425f1e07b#cb9f0ef5b800ce4a22cde1805e0eb88425f1e07b"
 dependencies = [
  "atomic-polyfill 1.0.1",
  "cfg-if",
@@ -415,6 +409,30 @@ dependencies = [
  "defmt",
  "embedded-io",
  "futures-util",
+ "heapless",
+]
+
+[[package]]
+name = "embassy-time"
+version = "0.1.0"
+source = "git+https://github.com/embassy-rs/embassy?rev=cb9f0ef5b800ce4a22cde1805e0eb88425f1e07b#cb9f0ef5b800ce4a22cde1805e0eb88425f1e07b"
+dependencies = [
+ "atomic-polyfill 1.0.1",
+ "cfg-if",
+ "critical-section 1.1.0",
+ "defmt",
+ "embassy-macros",
+ "embedded-hal 0.2.7",
+ "futures-util",
+]
+
+[[package]]
+name = "embassy-usb"
+version = "0.1.0"
+source = "git+https://github.com/embassy-rs/embassy?rev=cb9f0ef5b800ce4a22cde1805e0eb88425f1e07b#cb9f0ef5b800ce4a22cde1805e0eb88425f1e07b"
+dependencies = [
+ "defmt",
+ "embassy-futures",
  "heapless",
 ]
 
@@ -669,7 +687,7 @@ dependencies = [
  "critical-section 0.2.7",
  "critical-section 1.1.0",
  "defmt",
- "embassy-util",
+ "embassy-sync",
  "embedded-storage",
  "embedded-storage-async",
  "fixed",
@@ -690,6 +708,7 @@ dependencies = [
  "nrf52833-pac",
  "nrf52840-pac",
  "num_enum",
+ "static_cell",
 ]
 
 [[package]]
@@ -703,7 +722,8 @@ dependencies = [
  "defmt-rtt",
  "embassy-executor",
  "embassy-nrf",
- "embassy-util",
+ "embassy-sync",
+ "embassy-time",
  "embedded-storage",
  "embedded-storage-async",
  "fixed",
@@ -712,6 +732,7 @@ dependencies = [
  "nrf-softdevice",
  "nrf-softdevice-s140",
  "panic-probe",
+ "static_cell",
 ]
 
 [[package]]
@@ -1023,6 +1044,15 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_cell"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c37c250d21f53fa7165e76e5401d7e6539c211a8d2cf449e3962956a5cc2ce"
+dependencies = [
+ "atomic-polyfill 1.0.1",
+]
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,11 @@ exclude = [
 ]
 
 [patch.crates-io]
-embassy-executor = { git = "https://github.com/embassy-rs/embassy", rev = "d881f3ad9186cf3279aa1ba27093bad94035c186" }
-embassy-util = { git = "https://github.com/embassy-rs/embassy", rev = "d881f3ad9186cf3279aa1ba27093bad94035c186" }
-embassy-nrf = { git = "https://github.com/embassy-rs/embassy", rev = "d881f3ad9186cf3279aa1ba27093bad94035c186" }
-embassy-macros = { git = "https://github.com/embassy-rs/embassy", rev = "d881f3ad9186cf3279aa1ba27093bad94035c186" }
+embassy-executor = { git = "https://github.com/embassy-rs/embassy", rev = "cb9f0ef5b800ce4a22cde1805e0eb88425f1e07b" }
+embassy-sync = { git = "https://github.com/embassy-rs/embassy", rev = "cb9f0ef5b800ce4a22cde1805e0eb88425f1e07b" }
+embassy-time = { git = "https://github.com/embassy-rs/embassy", rev = "cb9f0ef5b800ce4a22cde1805e0eb88425f1e07b" }
+embassy-nrf = { git = "https://github.com/embassy-rs/embassy", rev = "cb9f0ef5b800ce4a22cde1805e0eb88425f1e07b" }
+embassy-macros = { git = "https://github.com/embassy-rs/embassy", rev = "cb9f0ef5b800ce4a22cde1805e0eb88425f1e07b" }
 
 [profile.release]
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ DO NOT disable the softdevice's interrupts. You MUST NOT use the widely-used `co
 
 - Make sure the `critical-section-impl` Cargo feature is enabled for `nrf-softdevice`. This makes `nrf-softdevice` emit a custom critical section implementation that disables only non-softdevice interrupts.
 - Use `critical_section::with` instead of `cortex_m::interrupt::free`. This uses the custom critical-section impl.
-- Use `embassy_util::blocking_mutex::CriticalSectionMutex` instead of `cortex_m::interrupt::Mutex`.
+- Use `embassy_sync::blocking_mutex::CriticalSectionMutex` instead of `cortex_m::interrupt::Mutex`.
 
 Make sure you're not using any library that internally uses `cortex_m::interrupt::free` as well.
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -16,8 +16,9 @@ ble-gatt-server = ["nrf-softdevice/ble-gatt-server"]
 ble-gatt-client = ["nrf-softdevice/ble-gatt-client"]
 
 [dependencies]
-embassy-executor = { version = "0.1.0", features = ["nightly", "defmt", "defmt-timestamp-uptime"]}
-embassy-util = { version = "0.1.0" }
+embassy-executor = { version = "0.1.0", features = [ "nightly", "defmt", "integrated-timers" ] }
+embassy-time = { version = "0.1.0", features = [ "defmt", "defmt-timestamp-uptime" ] }
+embassy-sync = { version = "0.1.0", features = [ "defmt" ] }
 embassy-nrf = { version = "0.1.0", features = [ "nightly", "defmt", "nrf52840", "gpiote", "time-driver-rtc1" ]}
 cortex-m = "0.7.2"
 cortex-m-rt = "0.7.0"
@@ -32,6 +33,7 @@ futures = { version = "0.3.5", default-features = false }
 fixed = "1.2.0"
 heapless = "0.7.1"
 atomic-pool = "0.2.1"
+static_cell = "1.0.0"
 
 [[bin]]
 name = "ble_bas_peripheral"

--- a/examples/src/bin/ble_advertise.rs
+++ b/examples/src/bin/ble_advertise.rs
@@ -10,9 +10,9 @@ use core::mem;
 use cortex_m_rt::entry;
 use defmt::{info, unreachable, *};
 use embassy_executor::Executor;
-use static_cell::StaticCell;
 use nrf_softdevice::ble::peripheral;
 use nrf_softdevice::{raw, Softdevice};
+use static_cell::StaticCell;
 
 static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 

--- a/examples/src/bin/ble_advertise.rs
+++ b/examples/src/bin/ble_advertise.rs
@@ -9,12 +9,12 @@ use core::mem;
 
 use cortex_m_rt::entry;
 use defmt::{info, unreachable, *};
-use embassy_executor::executor::Executor;
-use embassy_util::Forever;
+use embassy_executor::Executor;
+use static_cell::StaticCell;
 use nrf_softdevice::ble::peripheral;
 use nrf_softdevice::{raw, Softdevice};
 
-static EXECUTOR: Forever<Executor> = Forever::new();
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[embassy_executor::task]
 async fn softdevice_task(sd: &'static Softdevice) {
@@ -79,7 +79,7 @@ fn main() -> ! {
 
     let sd = Softdevice::enable(&config);
 
-    let executor = EXECUTOR.put(Executor::new());
+    let executor = EXECUTOR.init(Executor::new());
     executor.run(move |spawner| {
         unwrap!(spawner.spawn(softdevice_task(sd)));
         unwrap!(spawner.spawn(bluetooth_task(sd)));

--- a/examples/src/bin/ble_bas_central.rs
+++ b/examples/src/bin/ble_bas_central.rs
@@ -10,9 +10,9 @@ use core::mem;
 use cortex_m_rt::entry;
 use defmt::{info, *};
 use embassy_executor::Executor;
-use static_cell::StaticCell;
 use nrf_softdevice::ble::{central, gatt_client, Address, AddressType};
 use nrf_softdevice::{raw, Softdevice};
+use static_cell::StaticCell;
 
 static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 

--- a/examples/src/bin/ble_bas_central.rs
+++ b/examples/src/bin/ble_bas_central.rs
@@ -9,12 +9,12 @@ use core::mem;
 
 use cortex_m_rt::entry;
 use defmt::{info, *};
-use embassy_executor::executor::Executor;
-use embassy_util::Forever;
+use embassy_executor::Executor;
+use static_cell::StaticCell;
 use nrf_softdevice::ble::{central, gatt_client, Address, AddressType};
 use nrf_softdevice::{raw, Softdevice};
 
-static EXECUTOR: Forever<Executor> = Forever::new();
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[embassy_executor::task]
 async fn softdevice_task(sd: &'static Softdevice) {
@@ -89,7 +89,7 @@ fn main() -> ! {
 
     let sd = Softdevice::enable(&config);
 
-    let executor = EXECUTOR.put(Executor::new());
+    let executor = EXECUTOR.init(Executor::new());
     executor.run(move |spawner| {
         unwrap!(spawner.spawn(softdevice_task(sd)));
         unwrap!(spawner.spawn(ble_central_task(sd)));

--- a/examples/src/bin/ble_bas_peripheral.rs
+++ b/examples/src/bin/ble_bas_peripheral.rs
@@ -10,9 +10,9 @@ use core::mem;
 use cortex_m_rt::entry;
 use defmt::{info, *};
 use embassy_executor::Executor;
-use static_cell::StaticCell;
 use nrf_softdevice::ble::{gatt_server, peripheral};
 use nrf_softdevice::{raw, Softdevice};
+use static_cell::StaticCell;
 
 static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 

--- a/examples/src/bin/ble_bas_peripheral.rs
+++ b/examples/src/bin/ble_bas_peripheral.rs
@@ -9,12 +9,12 @@ use core::mem;
 
 use cortex_m_rt::entry;
 use defmt::{info, *};
-use embassy_executor::executor::Executor;
-use embassy_util::Forever;
+use embassy_executor::Executor;
+use static_cell::StaticCell;
 use nrf_softdevice::ble::{gatt_server, peripheral};
 use nrf_softdevice::{raw, Softdevice};
 
-static EXECUTOR: Forever<Executor> = Forever::new();
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[embassy_executor::task]
 async fn softdevice_task(sd: &'static Softdevice) {
@@ -125,7 +125,7 @@ fn main() -> ! {
 
     let sd = Softdevice::enable(&config);
 
-    let executor = EXECUTOR.put(Executor::new());
+    let executor = EXECUTOR.init(Executor::new());
     executor.run(move |spawner| {
         let server = unwrap!(Server::new(sd));
         unwrap!(spawner.spawn(softdevice_task(sd)));

--- a/examples/src/bin/ble_dis_bas_peripheral_builder.rs
+++ b/examples/src/bin/ble_dis_bas_peripheral_builder.rs
@@ -10,12 +10,12 @@ use core::mem;
 use cortex_m_rt::entry;
 use defmt::{info, *};
 use embassy_executor::Executor;
-use static_cell::StaticCell;
 use nrf_softdevice::ble::gatt_server::builder::ServiceBuilder;
 use nrf_softdevice::ble::gatt_server::characteristic::{Attribute, Metadata, Properties};
 use nrf_softdevice::ble::gatt_server::{CharacteristicHandles, RegisterError};
 use nrf_softdevice::ble::{gatt_server, peripheral, Connection, Uuid};
 use nrf_softdevice::{raw, Softdevice};
+use static_cell::StaticCell;
 
 const DEVICE_INFORMATION: Uuid = Uuid::new_16(0x180a);
 const BATTERY_SERVICE: Uuid = Uuid::new_16(0x180f);

--- a/examples/src/bin/ble_dis_bas_peripheral_builder.rs
+++ b/examples/src/bin/ble_dis_bas_peripheral_builder.rs
@@ -9,8 +9,8 @@ use core::mem;
 
 use cortex_m_rt::entry;
 use defmt::{info, *};
-use embassy_executor::executor::Executor;
-use embassy_util::Forever;
+use embassy_executor::Executor;
+use static_cell::StaticCell;
 use nrf_softdevice::ble::gatt_server::builder::ServiceBuilder;
 use nrf_softdevice::ble::gatt_server::characteristic::{Attribute, Metadata, Properties};
 use nrf_softdevice::ble::gatt_server::{CharacteristicHandles, RegisterError};
@@ -29,7 +29,7 @@ const SOFTWARE_REVISION: Uuid = Uuid::new_16(0x2a28);
 const MANUFACTURER_NAME: Uuid = Uuid::new_16(0x2a29);
 const PNP_ID: Uuid = Uuid::new_16(0x2a50);
 
-static EXECUTOR: Forever<Executor> = Forever::new();
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[embassy_executor::task]
 async fn softdevice_task(sd: &'static Softdevice) {
@@ -253,7 +253,7 @@ fn main() -> ! {
 
     let server = unwrap!(Server::new(sd, "12345678"));
 
-    let executor = EXECUTOR.put(Executor::new());
+    let executor = EXECUTOR.init(Executor::new());
     executor.run(move |spawner| {
         unwrap!(spawner.spawn(softdevice_task(sd)));
         unwrap!(spawner.spawn(bluetooth_task(sd, server)));

--- a/examples/src/bin/ble_l2cap_central.rs
+++ b/examples/src/bin/ble_l2cap_central.rs
@@ -11,10 +11,10 @@ use core::{mem, slice};
 use cortex_m_rt::entry;
 use defmt::{info, *};
 use embassy_executor::Executor;
-use static_cell::StaticCell;
 use nrf_softdevice::ble::l2cap::Packet as _;
 use nrf_softdevice::ble::{central, l2cap, Address, TxPower};
 use nrf_softdevice::{raw, Softdevice};
+use static_cell::StaticCell;
 
 static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 

--- a/examples/src/bin/ble_l2cap_central.rs
+++ b/examples/src/bin/ble_l2cap_central.rs
@@ -10,13 +10,13 @@ use core::{mem, slice};
 
 use cortex_m_rt::entry;
 use defmt::{info, *};
-use embassy_executor::executor::Executor;
-use embassy_util::Forever;
+use embassy_executor::Executor;
+use static_cell::StaticCell;
 use nrf_softdevice::ble::l2cap::Packet as _;
 use nrf_softdevice::ble::{central, l2cap, Address, TxPower};
 use nrf_softdevice::{raw, Softdevice};
 
-static EXECUTOR: Forever<Executor> = Forever::new();
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 const PSM: u16 = 0x2349;
 
@@ -180,7 +180,7 @@ fn main() -> ! {
 
     let sd = Softdevice::enable(&config);
 
-    let executor = EXECUTOR.put(Executor::new());
+    let executor = EXECUTOR.init(Executor::new());
     executor.run(move |spawner| {
         unwrap!(spawner.spawn(softdevice_task(sd)));
         unwrap!(spawner.spawn(ble_central_task(sd)));

--- a/examples/src/bin/ble_l2cap_peripheral.rs
+++ b/examples/src/bin/ble_l2cap_peripheral.rs
@@ -11,9 +11,9 @@ use core::ptr::NonNull;
 use cortex_m_rt::entry;
 use defmt::*;
 use embassy_executor::Executor;
-use static_cell::StaticCell;
 use nrf_softdevice::ble::{l2cap, peripheral};
 use nrf_softdevice::{ble, raw, RawError, Softdevice};
+use static_cell::StaticCell;
 
 static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 

--- a/examples/src/bin/ble_l2cap_peripheral.rs
+++ b/examples/src/bin/ble_l2cap_peripheral.rs
@@ -10,12 +10,12 @@ use core::ptr::NonNull;
 
 use cortex_m_rt::entry;
 use defmt::*;
-use embassy_executor::executor::Executor;
-use embassy_util::Forever;
+use embassy_executor::Executor;
+use static_cell::StaticCell;
 use nrf_softdevice::ble::{l2cap, peripheral};
 use nrf_softdevice::{ble, raw, RawError, Softdevice};
 
-static EXECUTOR: Forever<Executor> = Forever::new();
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 const PSM: u16 = 0x2349;
 
@@ -149,7 +149,7 @@ fn main() -> ! {
 
     unwrap!(RawError::convert(unsafe { raw::sd_clock_hfclk_request() }));
 
-    let executor = EXECUTOR.put(Executor::new());
+    let executor = EXECUTOR.init(Executor::new());
     executor.run(move |spawner| {
         unwrap!(spawner.spawn(softdevice_task(sd)));
         unwrap!(spawner.spawn(bluetooth_task(sd)));

--- a/examples/src/bin/ble_peripheral_onoff.rs
+++ b/examples/src/bin/ble_peripheral_onoff.rs
@@ -9,15 +9,15 @@ use core::mem;
 
 use cortex_m_rt::entry;
 use defmt::*;
-use embassy_executor::executor::Executor;
+use embassy_executor::Executor;
 use embassy_nrf::gpio::{AnyPin, Input, Pin as _, Pull};
 use embassy_nrf::interrupt::Priority;
-use embassy_util::Forever;
+use static_cell::StaticCell;
 use futures::pin_mut;
 use nrf_softdevice::ble::{gatt_server, peripheral};
 use nrf_softdevice::{raw, Softdevice};
 
-static EXECUTOR: Forever<Executor> = Forever::new();
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[embassy_executor::task]
 async fn softdevice_task(sd: &'static Softdevice) {
@@ -158,7 +158,7 @@ fn main() -> ! {
 
     let sd = Softdevice::enable(&config);
 
-    let executor = EXECUTOR.put(Executor::new());
+    let executor = EXECUTOR.init(Executor::new());
     executor.run(move |spawner| {
         let server = unwrap!(Server::new(sd));
         unwrap!(spawner.spawn(softdevice_task(sd)));

--- a/examples/src/bin/ble_peripheral_onoff.rs
+++ b/examples/src/bin/ble_peripheral_onoff.rs
@@ -12,10 +12,10 @@ use defmt::*;
 use embassy_executor::Executor;
 use embassy_nrf::gpio::{AnyPin, Input, Pin as _, Pull};
 use embassy_nrf::interrupt::Priority;
-use static_cell::StaticCell;
 use futures::pin_mut;
 use nrf_softdevice::ble::{gatt_server, peripheral};
 use nrf_softdevice::{raw, Softdevice};
+use static_cell::StaticCell;
 
 static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 

--- a/examples/src/bin/ble_scan.rs
+++ b/examples/src/bin/ble_scan.rs
@@ -9,12 +9,12 @@ use core::{mem, slice};
 
 use cortex_m_rt::entry;
 use defmt::*;
-use embassy_executor::executor::Executor;
-use embassy_util::Forever;
+use embassy_executor::Executor;
+use static_cell::StaticCell;
 use nrf_softdevice::ble::central;
 use nrf_softdevice::{raw, Softdevice};
 
-static EXECUTOR: Forever<Executor> = Forever::new();
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[embassy_executor::task]
 async fn softdevice_task(sd: &'static Softdevice) {
@@ -100,7 +100,7 @@ fn main() -> ! {
 
     let sd = Softdevice::enable(&config);
 
-    let executor = EXECUTOR.put(Executor::new());
+    let executor = EXECUTOR.init(Executor::new());
     executor.run(move |spawner| {
         unwrap!(spawner.spawn(softdevice_task(sd)));
         unwrap!(spawner.spawn(ble_task(sd)));

--- a/examples/src/bin/ble_scan.rs
+++ b/examples/src/bin/ble_scan.rs
@@ -10,9 +10,9 @@ use core::{mem, slice};
 use cortex_m_rt::entry;
 use defmt::*;
 use embassy_executor::Executor;
-use static_cell::StaticCell;
 use nrf_softdevice::ble::central;
 use nrf_softdevice::{raw, Softdevice};
+use static_cell::StaticCell;
 
 static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 

--- a/examples/src/bin/flash.rs
+++ b/examples/src/bin/flash.rs
@@ -7,13 +7,13 @@ mod example_common;
 
 use cortex_m_rt::entry;
 use defmt::*;
-use embassy_executor::executor::Executor;
-use embassy_util::Forever;
+use embassy_executor::Executor;
+use static_cell::StaticCell;
 use embedded_storage_async::nor_flash::*;
 use futures::pin_mut;
 use nrf_softdevice::{Flash, Softdevice};
 
-static EXECUTOR: Forever<Executor> = Forever::new();
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[embassy_executor::task]
 async fn softdevice_task(sd: &'static Softdevice) {
@@ -40,7 +40,7 @@ fn main() -> ! {
 
     let sd = Softdevice::enable(&Default::default());
 
-    let executor = EXECUTOR.put(Executor::new());
+    let executor = EXECUTOR.init(Executor::new());
     executor.run(move |spawner| {
         unwrap!(spawner.spawn(softdevice_task(sd)));
         unwrap!(spawner.spawn(flash_task(sd)));

--- a/examples/src/bin/flash.rs
+++ b/examples/src/bin/flash.rs
@@ -8,10 +8,10 @@ mod example_common;
 use cortex_m_rt::entry;
 use defmt::*;
 use embassy_executor::Executor;
-use static_cell::StaticCell;
 use embedded_storage_async::nor_flash::*;
 use futures::pin_mut;
 use nrf_softdevice::{Flash, Softdevice};
+use static_cell::StaticCell;
 
 static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 

--- a/nrf-softdevice/Cargo.toml
+++ b/nrf-softdevice/Cargo.toml
@@ -42,7 +42,7 @@ critical-section-02 = { package = "critical-section", version = "0.2", optional 
 critical-section-1 = { package = "critical-section", version = "1.0", optional = true }
 
 num_enum = { version = "0.5.1", default-features = false }
-embassy-util = { version = "0.1.0" }
+embassy-sync = { version = "0.1.0" }
 cortex-m = "0.7.2"
 cortex-m-rt = ">=0.6.15,<0.8"
 heapless = "0.7.1"
@@ -66,6 +66,7 @@ nrf-softdevice-s132 = { version = "0.1.1", path = "../nrf-softdevice-s132", opti
 nrf-softdevice-s140 = { version = "0.1.1", path = "../nrf-softdevice-s140", optional = true }
 
 nrf-softdevice-macro = { version = "0.1.0", path = "../nrf-softdevice-macro" }
+static_cell = "1.0.0"
 
 [package.metadata.docs.rs]
 targets = ["thumbv7em-none-eabi"]

--- a/nrf-softdevice/src/events.rs
+++ b/nrf-softdevice/src/events.rs
@@ -1,7 +1,7 @@
 use core::mem::MaybeUninit;
 use core::task::Poll;
 
-use embassy_util::waitqueue::AtomicWaker;
+use embassy_sync::waitqueue::AtomicWaker;
 use futures::future::poll_fn;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 

--- a/nrf-softdevice/src/softdevice.rs
+++ b/nrf-softdevice/src/softdevice.rs
@@ -85,7 +85,7 @@ fn cfg_set(id: u32, cfg: &raw::ble_cfg_t) {
 }
 
 // embassy_util::Forever was replaced with static_cell::StaticCell, but the latter doesn't have a steal() method so we have to use UnsafeCell and MaybeUninit directly.
-struct SoftdeviceHolder (UnsafeCell<MaybeUninit<Softdevice>>);
+struct SoftdeviceHolder(UnsafeCell<MaybeUninit<Softdevice>>);
 
 unsafe impl Send for SoftdeviceHolder {}
 unsafe impl Sync for SoftdeviceHolder {}


### PR DESCRIPTION
The only sketchy thing is that I had to replace `Forever` with `UnsafeCell<MaybeUninit<_>>` in `softdevice.rs`; that could probably use scrutiny. (Embassy got rid of `Forever` and the replacement `StaticCell` doesn't have a `steal` method.)