### PR TITLE
Add `gatt_server::set_sys_attrs` function

### DIFF
--- a/nrf-softdevice/src/ble/connection.rs
+++ b/nrf-softdevice/src/ble/connection.rs
@@ -248,6 +248,7 @@ impl ConnectionState {
     }
 }
 
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Connection {
     index: u8,
 }

--- a/nrf-softdevice/src/ble/replies.rs
+++ b/nrf-softdevice/src/ble/replies.rs
@@ -1,6 +1,9 @@
+#[cfg(any(feature = "ble-sec", feature = "ble-gatt-server"))]
 use core::mem::ManuallyDrop;
 
+#[cfg(any(feature = "ble-sec", feature = "ble-gatt-server"))]
 use super::Connection;
+#[cfg(any(feature = "ble-sec", feature = "ble-gatt-server"))]
 use crate::{raw, RawError};
 
 #[cfg(feature = "ble-sec")]
@@ -84,54 +87,6 @@ impl OutOfBandReply {
         let res = if let Some(conn_handle) = self.conn.handle() {
             let ptr = oob.map(|x| x.as_ptr()).unwrap_or(core::ptr::null());
             let ret = raw::sd_ble_gap_auth_key_reply(conn_handle, raw::BLE_GAP_AUTH_KEY_TYPE_OOB as u8, ptr);
-            RawError::convert(ret)
-        } else {
-            Err(RawError::InvalidState)
-        };
-
-        // Since conn is ManuallyDrop, we must drop it here
-        ManuallyDrop::drop(&mut self.conn);
-        res
-    }
-}
-
-pub struct SysAttrsReply {
-    conn: ManuallyDrop<Connection>,
-}
-
-impl Drop for SysAttrsReply {
-    fn drop(&mut self) {
-        if let Err(_err) = unsafe { self.finalize(None) } {
-            warn!("sd_ble_gatts_sys_attr_set err {:?}", _err);
-        }
-    }
-}
-
-impl SysAttrsReply {
-    pub fn new(conn: Connection) -> Self {
-        Self {
-            conn: ManuallyDrop::new(conn),
-        }
-    }
-
-    pub fn connection(&self) -> &Connection {
-        &self.conn
-    }
-
-    pub fn set_sys_attrs(mut self, sys_attrs: Option<&[u8]>) -> Result<(), RawError> {
-        let res = unsafe { self.finalize(sys_attrs) };
-        core::mem::forget(self); // Prevent Drop from finalizing a second time
-        res
-    }
-
-    /// # Safety
-    ///
-    /// This method must be called exactly once
-    unsafe fn finalize(&mut self, sys_attrs: Option<&[u8]>) -> Result<(), RawError> {
-        let res = if let Some(conn_handle) = self.conn.handle() {
-            let ptr = sys_attrs.map(|x| x.as_ptr()).unwrap_or(core::ptr::null());
-            let len = sys_attrs.map(|x| x.len()).unwrap_or_default();
-            let ret = raw::sd_ble_gatts_sys_attr_set(conn_handle, ptr, unwrap!(len.try_into()), 0);
             RawError::convert(ret)
         } else {
             Err(RawError::InvalidState)

--- a/nrf-softdevice/src/ble/security.rs
+++ b/nrf-softdevice/src/ble/security.rs
@@ -83,5 +83,12 @@ pub trait SecurityHandler {
 
     #[cfg(feature = "ble-gatt-server")]
     /// Load the GATTS system attributes for the bond associated with `conn`
-    fn load_sys_attrs(&self, _setter: super::replies::SysAttrsReply) {}
+    ///
+    /// If no system attributes have been stored for this peer, you should call
+    /// [set_sys_attrs][super::gatt_server::set_sys_attrs] with a `sys_attrs` parameter of `None`.
+    fn load_sys_attrs(&self, conn: &super::Connection) {
+        if let Err(err) = super::gatt_server::set_sys_attrs(conn, None) {
+            warn!("SecurityHandler failed to set sys attrs: {:?}", err);
+        }
+    }
 }


### PR DESCRIPTION
Also removes `replies::SysAttrReply`. Implementers of `SecurityHandler::load_sys_attrs` should call `set_sys_attrs` directly.