### PR TITLE
Add missing peripheral advertising parameters

### DIFF
--- a/nrf-softdevice/src/ble/mod.rs
+++ b/nrf-softdevice/src/ble/mod.rs
@@ -1,17 +1,18 @@
 //! Bluetooth Low Energy
 
 mod connection;
+mod gap;
 mod gatt_traits;
 mod replies;
 mod types;
 
 pub use connection::*;
+pub use gap::*;
 pub use gatt_traits::*;
 pub use replies::*;
 pub use types::*;
 
 mod common;
-mod gap;
 
 #[cfg(feature = "ble-sec")]
 pub mod security;


### PR DESCRIPTION
Adds support for (most) remaining softdevice advertising parameters.

Also removes `adv_data`/`scan_data` from advertisement kinds that do not allow that type of data.