### PR TITLE
Enable defmt logging info env by default

### DIFF
--- a/examples/.cargo/config
+++ b/examples/.cargo/config
@@ -7,3 +7,6 @@ runner = "probe-run --chip nRF52840_xxAA"
 # target = "thumbv7m-none-eabi"    # Cortex-M3
 # target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
 target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
+
+[env]
+DEFMT_LOG = "info"


### PR DESCRIPTION
Prevents the issue where someone forgets to set DEFMT_LOG and doesn't see any input.