### PR TITLE
event: Work with larger messages

### DIFF
--- a/nrf-softdevice/Cargo.toml
+++ b/nrf-softdevice/Cargo.toml
@@ -36,6 +36,9 @@ critical-section-impl = ["critical-section-1/restore-state-bool", "critical-sect
 # https://devzone.nordicsemi.com/f/nordic-q-a/81894/s140-7-3-0-softdevice-assertion-failed-at-pc-0xa806-using-l2cap
 ble-l2cap-credit-wrokaround = []
 
+evt-max-size-256 = []
+evt-max-size-512 = []
+
 [dependencies]
 defmt = { version = "0.3", optional = true }
 log = { version = "0.4.11", optional = true }

--- a/nrf-softdevice/src/events.rs
+++ b/nrf-softdevice/src/events.rs
@@ -74,7 +74,7 @@ pub(crate) async fn run<F: FnMut(SocEvent)>(mut soc_evt_handler: F) -> ! {
                 Ok(()) => crate::ble::on_evt(evt.as_ptr() as *const raw::ble_evt_t),
                 Err(RawError::NotFound) => break,
                 Err(RawError::BleNotEnabled) => break,
-                Err(RawError::NoMem) => panic!("BUG: BLE_EVT_MAX_SIZE is too low"),
+                Err(RawError::DataSize) => panic!("BUG: BLE_EVT_MAX_SIZE is too low"),
                 Err(err) => panic!("sd_ble_evt_get err {:?}", err),
             }
         }


### PR DESCRIPTION
The recognized error in sd_ble_evt_get was not the one that's raised when BLE_EVT_MAX_SIZE is exceeded -- fixed in a first commit.

The larger issue is that BLE_EVT_MAX_SIZE (allocated on the stack) really depends on a run-time variable. Introducing a feature to increase it is a workaround that'd help users not have to fork softdevice just to increase the limit. 512 was chosen arbitrarily, or by "half or double" rule. If larger MTUs even make sense (don't know off my head), a 1024 might make sense as well.

Potential further improvements:
* We could pass the configured size on at run time, and check whether the feature-configured size is guaranteed to be sufficient. It's a bit of a runtime overhead but would have the benefit of failing right away when the feature configuration is misaligned with the softdevice configuration, rather than only failing when large messages are really encountered.
* On the long run, I have a hunch that the Softdevice configuration should, at least in parts, be a const argument (well, actually that'd be implemented as a generic). Then a precise buffer size would be known at build time.