### PR TITLE
Use reference for `write`, `notify` and `indicate`

### DIFF
--- a/examples/src/bin/ble_bas_central.rs
+++ b/examples/src/bin/ble_bas_central.rs
@@ -76,7 +76,7 @@ async fn main(spawner: Spawner) {
     info!("read battery level: {}", val);
 
     // Write, set it to 42
-    unwrap!(client.battery_level_write(42).await);
+    unwrap!(client.battery_level_write(&42).await);
     info!("Wrote battery level!");
 
     // Read to check it's changed

--- a/examples/src/bin/ble_bas_peripheral.rs
+++ b/examples/src/bin/ble_bas_peripheral.rs
@@ -104,7 +104,7 @@ async fn main(spawner: Spawner) {
             ServerEvent::Foo(e) => match e {
                 FooServiceEvent::FooWrite(val) => {
                     info!("wrote foo: {}", val);
-                    if let Err(e) = server.foo.foo_notify(&conn, val + 1) {
+                    if let Err(e) = server.foo.foo_notify(&conn, &(val + 1)) {
                         info!("send notification error: {:?}", e);
                     }
                 }

--- a/examples/src/bin/ble_bas_peripheral_notify.rs
+++ b/examples/src/bin/ble_bas_peripheral_notify.rs
@@ -55,9 +55,9 @@ async fn notify_adc_value<'a>(saadc: &'a mut Saadc<'_, 1>, server: &'a Server, c
         let adc_raw_value: i16 = buf[0];
 
         // Try and notify the connected client of the new ADC value.
-        match server.bas.battery_level_notify(connection, adc_raw_value) {
+        match server.bas.battery_level_notify(connection, &adc_raw_value) {
             Ok(_) => info!("Battery adc_raw_value: {=i16}", &adc_raw_value),
-            Err(_) => unwrap!(server.bas.battery_level_set(adc_raw_value)),
+            Err(_) => unwrap!(server.bas.battery_level_set(&adc_raw_value)),
         };
 
         // Sleep for one second.

--- a/examples/src/bin/ble_peripheral_onoff.rs
+++ b/examples/src/bin/ble_peripheral_onoff.rs
@@ -55,7 +55,7 @@ async fn run_bluetooth(sd: &'static Softdevice, server: &Server) {
         let res = gatt_server::run(&conn, server, |e| match e {
             ServerEvent::Foo(FooServiceEvent::FooWrite(val)) => {
                 info!("wrote foo level: {}", val);
-                if let Err(e) = server.foo.foo_notify(&conn, val + 1) {
+                if let Err(e) = server.foo.foo_notify(&conn, &(val + 1)) {
                     info!("send notification error: {:?}", e);
                 }
             }

--- a/nrf-softdevice-macro/src/lib.rs
+++ b/nrf-softdevice-macro/src/lib.rs
@@ -260,7 +260,7 @@ pub fn gatt_service(args: TokenStream, item: TokenStream) -> TokenStream {
                 Ok(#ty_as_val::from_gatt(&buf[..size]))
             }
 
-            #fn_vis fn #set_fn(&self, val: #ty) -> Result<(), #ble::gatt_server::SetValueError> {
+            #fn_vis fn #set_fn(&self, val: &#ty) -> Result<(), #ble::gatt_server::SetValueError> {
                 let sd = unsafe { ::nrf_softdevice::Softdevice::steal() };
                 let buf = #ty_as_val::to_gatt(&val);
                 #ble::gatt_server::set_value(sd, self.#value_handle, buf)
@@ -301,7 +301,7 @@ pub fn gatt_service(args: TokenStream, item: TokenStream) -> TokenStream {
                 #fn_vis fn #notify_fn(
                     &self,
                     conn: &#ble::Connection,
-                    val: #ty,
+                    val: &#ty,
                 ) -> Result<(), #ble::gatt_server::NotifyValueError> {
                     let buf = #ty_as_val::to_gatt(&val);
                     #ble::gatt_server::notify_value(conn, self.#value_handle, buf)
@@ -331,7 +331,7 @@ pub fn gatt_service(args: TokenStream, item: TokenStream) -> TokenStream {
                 fn #indicate_fn(
                     &self,
                     conn: &#ble::Connection,
-                    val: #ty,
+                    val: &#ty,
                 ) -> Result<(), #ble::gatt_server::IndicateValueError> {
                     let buf = #ty_as_val::to_gatt(&val);
                     #ble::gatt_server::indicate_value(conn, self.#value_handle, buf)
@@ -580,15 +580,15 @@ pub fn gatt_client(args: TokenStream, item: TokenStream) -> TokenStream {
 
         if write {
             code_impl.extend(quote_spanned!(ch.span=>
-                async fn #write_fn(&self, val: #ty) -> Result<(), #ble::gatt_client::WriteError> {
+                async fn #write_fn(&self, val: &#ty) -> Result<(), #ble::gatt_client::WriteError> {
                     let buf = #ty_as_val::to_gatt(&val);
                     #ble::gatt_client::write(&self.conn, self.#value_handle, buf).await
                 }
-                async fn #write_wor_fn(&self, val: #ty) -> Result<(), #ble::gatt_client::WriteError> {
+                async fn #write_wor_fn(&self, val: &#ty) -> Result<(), #ble::gatt_client::WriteError> {
                     let buf = #ty_as_val::to_gatt(&val);
                     #ble::gatt_client::write_without_response(&self.conn, self.#value_handle, buf).await
                 }
-                fn #write_try_wor_fn(&self, val: #ty) -> Result<(), #ble::gatt_client::TryWriteError> {
+                fn #write_try_wor_fn(&self, val: &#ty) -> Result<(), #ble::gatt_client::TryWriteError> {
                     let buf = #ty_as_val::to_gatt(&val);
                     #ble::gatt_client::try_write_without_response(&self.conn, self.#value_handle, buf)
                 }

--- a/nrf-softdevice-macro/src/lib.rs
+++ b/nrf-softdevice-macro/src/lib.rs
@@ -262,7 +262,7 @@ pub fn gatt_service(args: TokenStream, item: TokenStream) -> TokenStream {
 
             #fn_vis fn #set_fn(&self, val: &#ty) -> Result<(), #ble::gatt_server::SetValueError> {
                 let sd = unsafe { ::nrf_softdevice::Softdevice::steal() };
-                let buf = #ty_as_val::to_gatt(&val);
+                let buf = #ty_as_val::to_gatt(val);
                 #ble::gatt_server::set_value(sd, self.#value_handle, buf)
             }
         ));
@@ -303,7 +303,7 @@ pub fn gatt_service(args: TokenStream, item: TokenStream) -> TokenStream {
                     conn: &#ble::Connection,
                     val: &#ty,
                 ) -> Result<(), #ble::gatt_server::NotifyValueError> {
-                    let buf = #ty_as_val::to_gatt(&val);
+                    let buf = #ty_as_val::to_gatt(val);
                     #ble::gatt_server::notify_value(conn, self.#value_handle, buf)
                 }
             ));
@@ -333,7 +333,7 @@ pub fn gatt_service(args: TokenStream, item: TokenStream) -> TokenStream {
                     conn: &#ble::Connection,
                     val: &#ty,
                 ) -> Result<(), #ble::gatt_server::IndicateValueError> {
-                    let buf = #ty_as_val::to_gatt(&val);
+                    let buf = #ty_as_val::to_gatt(val);
                     #ble::gatt_server::indicate_value(conn, self.#value_handle, buf)
                 }
             ));
@@ -581,15 +581,15 @@ pub fn gatt_client(args: TokenStream, item: TokenStream) -> TokenStream {
         if write {
             code_impl.extend(quote_spanned!(ch.span=>
                 async fn #write_fn(&self, val: &#ty) -> Result<(), #ble::gatt_client::WriteError> {
-                    let buf = #ty_as_val::to_gatt(&val);
+                    let buf = #ty_as_val::to_gatt(val);
                     #ble::gatt_client::write(&self.conn, self.#value_handle, buf).await
                 }
                 async fn #write_wor_fn(&self, val: &#ty) -> Result<(), #ble::gatt_client::WriteError> {
-                    let buf = #ty_as_val::to_gatt(&val);
+                    let buf = #ty_as_val::to_gatt(val);
                     #ble::gatt_client::write_without_response(&self.conn, self.#value_handle, buf).await
                 }
                 fn #write_try_wor_fn(&self, val: &#ty) -> Result<(), #ble::gatt_client::TryWriteError> {
-                    let buf = #ty_as_val::to_gatt(&val);
+                    let buf = #ty_as_val::to_gatt(val);
                     #ble::gatt_client::try_write_without_response(&self.conn, self.#value_handle, buf)
                 }
             ));


### PR DESCRIPTION
Since `nrf-macro` supports `heapless::Vec` as characteristics, I wanted to avoid unnecessary copy and reuse the `Vec`. Internally, all functions called `to_gatt` internally which uses a reference anyway. The gatt client and peripheral were modified.

This is breaking change so I'm not sure what would be the preferred way to do this or if it's a non-issue since it's not released yet. 