### PR TITLE
Add report descriptors to gatt_service macro

### DIFF
--- a/nrf-softdevice-macro/src/lib.rs
+++ b/nrf-softdevice-macro/src/lib.rs
@@ -240,21 +240,34 @@ pub fn gatt_service(args: TokenStream, item: TokenStream) -> TokenStream {
         });
 
         // Only one of input, output or feature is allowed
-        assert!(input_report.map_or(0, |_| 1) + output_report.map_or(0, |_| 1) + feature_report.map_or(0, |_| 1) <= 1,
-            "Only one of input, output or feature is allowed for each characteristic");
+        assert!(
+            input_report.map_or(0, |_| 1) + output_report.map_or(0, |_| 1) + feature_report.map_or(0, |_| 1) <= 1,
+            "Only one of input, output or feature is allowed for each characteristic"
+        );
 
         let report = if let Some(input_report) = input_report {
-            Some((input_report, quote!(#ble::gatt_server::characteristic::ReportDescriptorType::Input)))
+            Some((
+                input_report,
+                quote!(#ble::gatt_server::characteristic::ReportDescriptorType::Input),
+            ))
         } else if let Some(output_report) = output_report {
-            Some((output_report, quote!(#ble::gatt_server::characteristic::ReportDescriptorType::Output)))
+            Some((
+                output_report,
+                quote!(#ble::gatt_server::characteristic::ReportDescriptorType::Output),
+            ))
         } else if let Some(feature_report) = feature_report {
-            Some((feature_report, quote!(#ble::gatt_server::characteristic::ReportDescriptorType::Feature)))
-        } else {None};
+            Some((
+                feature_report,
+                quote!(#ble::gatt_server::characteristic::ReportDescriptorType::Feature),
+            ))
+        } else {
+            None
+        };
 
         if let Some((desc_id, desc_type)) = report {
             code_build_desc.extend(quote_spanned!(ch.span=>
                 let desc = #ble::gatt_server::characteristic::ReportDescriptor {
-                    id: #desc_id, 
+                    id: #desc_id,
                     desc_type: #desc_type,
                 };
                 let desc_attr = #ble::gatt_server::characteristic::Attribute::new(&desc);

--- a/nrf-softdevice/src/ble/gatt_server/characteristic.rs
+++ b/nrf-softdevice/src/ble/gatt_server/characteristic.rs
@@ -267,7 +267,7 @@ impl Metadata {
 pub enum ReportDescriptorType {
     Input = 1,
     Output = 2,
-    Feature = 3
+    Feature = 3,
 }
 
 #[derive(Copy, Clone)]

--- a/nrf-softdevice/src/ble/gatt_server/characteristic.rs
+++ b/nrf-softdevice/src/ble/gatt_server/characteristic.rs
@@ -260,3 +260,22 @@ impl Metadata {
         }
     }
 }
+
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(C, packed)]
+pub struct ReportDescriptor {
+    pub id: u8,
+    pub desc_type: u8,
+}
+
+impl AsRef<[u8]> for ReportDescriptor {
+    fn as_ref(&self) -> &[u8] {
+        unsafe {
+            ::core::slice::from_raw_parts(
+                &self as *const _ as *const u8,
+                ::core::mem::size_of::<ReportDescriptor>(),
+            )
+        }
+    }
+}

--- a/nrf-softdevice/src/ble/gatt_server/characteristic.rs
+++ b/nrf-softdevice/src/ble/gatt_server/characteristic.rs
@@ -263,17 +263,26 @@ impl Metadata {
 
 #[derive(Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum ReportDescriptorType {
+    Input = 1,
+    Output = 2,
+    Feature = 3
+}
+
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(C, packed)]
 pub struct ReportDescriptor {
     pub id: u8,
-    pub desc_type: u8,
+    pub desc_type: ReportDescriptorType,
 }
 
 impl AsRef<[u8]> for ReportDescriptor {
     fn as_ref(&self) -> &[u8] {
         unsafe {
             ::core::slice::from_raw_parts(
-                &self as *const _ as *const u8,
+                self as *const _ as *const u8,
                 ::core::mem::size_of::<ReportDescriptor>(),
             )
         }


### PR DESCRIPTION
This PR adds syntax for declaring report descriptors in the gatt_service macro. Three additional keywords have been added to the characteristics to be able to declare a characteristic as an input, output or feature report, and which report id it has in the report map. This is required by the HIDS protocol.

In this example of a HID Service there are three input reports declared, which correspond to the reports in the report map (not shown here). 

```rust
#[nrf_softdevice::gatt_service(uuid = "1812")]
pub struct HIDService {
    #[characteristic(uuid = "2a4e", read, write_without_response)]
    pub protocol_mode: ProtocolMode,

    #[characteristic(uuid = "2a4b", read)]
    pub report_map: ReportMap,

    #[characteristic(uuid = "2a4d", read, notify, input = 3)]
    pub mouse_input_report: MouseReport,

    #[characteristic(uuid ="2a4d", read, notify, input = 1)]
    pub keyboard_input_report: KeyboardReport,

    #[characteristic(uuid ="2a4d", read, notify, input = 2)]
    pub consumer_input_report: ConsumerReport,

    #[characteristic(uuid = "2a33", read, notify)]
    pub boot_mouse_input_report: MouseReport,

    #[characteristic(uuid = "2a22", read, notify)]
    pub boot_keyboard_input_report: KeyboardReport,

    #[characteristic(uuid = "2a4a", read)]
    pub hid_information: HIDInformation,

    #[characteristic(uuid = "2a4c", write_without_response)]
    hid_control: HIDControlPoint,
}
```