### PR TITLE
Fix nRF clock accuracy setting in examples

### DIFF
--- a/examples/src/bin/ble_advertise.rs
+++ b/examples/src/bin/ble_advertise.rs
@@ -26,7 +26,7 @@ async fn main(spawner: Spawner) {
             source: raw::NRF_CLOCK_LF_SRC_RC as u8,
             rc_ctiv: 4,
             rc_temp_ctiv: 2,
-            accuracy: 7,
+            accuracy: raw::NRF_CLOCK_LF_ACCURACY_500_PPM as u8,
         }),
         conn_gap: Some(raw::ble_gap_conn_cfg_t {
             conn_count: 6,

--- a/examples/src/bin/ble_advertise.rs
+++ b/examples/src/bin/ble_advertise.rs
@@ -24,7 +24,7 @@ async fn main(spawner: Spawner) {
     let config = nrf_softdevice::Config {
         clock: Some(raw::nrf_clock_lf_cfg_t {
             source: raw::NRF_CLOCK_LF_SRC_RC as u8,
-            rc_ctiv: 4,
+            rc_ctiv: 16,
             rc_temp_ctiv: 2,
             accuracy: raw::NRF_CLOCK_LF_ACCURACY_500_PPM as u8,
         }),

--- a/examples/src/bin/ble_bas_central.rs
+++ b/examples/src/bin/ble_bas_central.rs
@@ -32,7 +32,7 @@ async fn main(spawner: Spawner) {
             source: raw::NRF_CLOCK_LF_SRC_RC as u8,
             rc_ctiv: 4,
             rc_temp_ctiv: 2,
-            accuracy: 7,
+            accuracy: raw::NRF_CLOCK_LF_ACCURACY_500_PPM as u8,
         }),
         conn_gap: Some(raw::ble_gap_conn_cfg_t {
             conn_count: 6,

--- a/examples/src/bin/ble_bas_central.rs
+++ b/examples/src/bin/ble_bas_central.rs
@@ -30,7 +30,7 @@ async fn main(spawner: Spawner) {
     let config = nrf_softdevice::Config {
         clock: Some(raw::nrf_clock_lf_cfg_t {
             source: raw::NRF_CLOCK_LF_SRC_RC as u8,
-            rc_ctiv: 4,
+            rc_ctiv: 16,
             rc_temp_ctiv: 2,
             accuracy: raw::NRF_CLOCK_LF_ACCURACY_500_PPM as u8,
         }),

--- a/examples/src/bin/ble_bas_peripheral.rs
+++ b/examples/src/bin/ble_bas_peripheral.rs
@@ -42,7 +42,7 @@ async fn main(spawner: Spawner) {
     let config = nrf_softdevice::Config {
         clock: Some(raw::nrf_clock_lf_cfg_t {
             source: raw::NRF_CLOCK_LF_SRC_RC as u8,
-            rc_ctiv: 4,
+            rc_ctiv: 16,
             rc_temp_ctiv: 2,
             accuracy: raw::NRF_CLOCK_LF_ACCURACY_500_PPM as u8,
         }),

--- a/examples/src/bin/ble_bas_peripheral.rs
+++ b/examples/src/bin/ble_bas_peripheral.rs
@@ -44,7 +44,7 @@ async fn main(spawner: Spawner) {
             source: raw::NRF_CLOCK_LF_SRC_RC as u8,
             rc_ctiv: 4,
             rc_temp_ctiv: 2,
-            accuracy: 7,
+            accuracy: raw::NRF_CLOCK_LF_ACCURACY_500_PPM as u8,
         }),
         conn_gap: Some(raw::ble_gap_conn_cfg_t {
             conn_count: 6,

--- a/examples/src/bin/ble_bond_peripheral.rs
+++ b/examples/src/bin/ble_bond_peripheral.rs
@@ -190,7 +190,7 @@ async fn main(spawner: Spawner) -> ! {
     let config = nrf_softdevice::Config {
         clock: Some(raw::nrf_clock_lf_cfg_t {
             source: raw::NRF_CLOCK_LF_SRC_RC as u8,
-            rc_ctiv: 4,
+            rc_ctiv: 16,
             rc_temp_ctiv: 2,
             accuracy: raw::NRF_CLOCK_LF_ACCURACY_500_PPM as u8,
         }),

--- a/examples/src/bin/ble_bond_peripheral.rs
+++ b/examples/src/bin/ble_bond_peripheral.rs
@@ -192,7 +192,7 @@ async fn main(spawner: Spawner) -> ! {
             source: raw::NRF_CLOCK_LF_SRC_RC as u8,
             rc_ctiv: 4,
             rc_temp_ctiv: 2,
-            accuracy: 7,
+            accuracy: raw::NRF_CLOCK_LF_ACCURACY_500_PPM as u8,
         }),
         conn_gap: Some(raw::ble_gap_conn_cfg_t {
             conn_count: 6,

--- a/examples/src/bin/ble_dis_bas_peripheral_builder.rs
+++ b/examples/src/bin/ble_dis_bas_peripheral_builder.rs
@@ -198,7 +198,7 @@ async fn main(spawner: Spawner) {
             source: raw::NRF_CLOCK_LF_SRC_RC as u8,
             rc_ctiv: 4,
             rc_temp_ctiv: 2,
-            accuracy: 7,
+            accuracy: raw::NRF_CLOCK_LF_ACCURACY_500_PPM as u8,
         }),
         conn_gap: Some(raw::ble_gap_conn_cfg_t {
             conn_count: 6,

--- a/examples/src/bin/ble_dis_bas_peripheral_builder.rs
+++ b/examples/src/bin/ble_dis_bas_peripheral_builder.rs
@@ -196,7 +196,7 @@ async fn main(spawner: Spawner) {
     let config = nrf_softdevice::Config {
         clock: Some(raw::nrf_clock_lf_cfg_t {
             source: raw::NRF_CLOCK_LF_SRC_RC as u8,
-            rc_ctiv: 4,
+            rc_ctiv: 16,
             rc_temp_ctiv: 2,
             accuracy: raw::NRF_CLOCK_LF_ACCURACY_500_PPM as u8,
         }),

--- a/examples/src/bin/ble_l2cap_central.rs
+++ b/examples/src/bin/ble_l2cap_central.rs
@@ -79,7 +79,7 @@ async fn main(spawner: Spawner) {
     let config = nrf_softdevice::Config {
         clock: Some(raw::nrf_clock_lf_cfg_t {
             source: raw::NRF_CLOCK_LF_SRC_RC as u8,
-            rc_ctiv: 4,
+            rc_ctiv: 16,
             rc_temp_ctiv: 2,
             accuracy: raw::NRF_CLOCK_LF_ACCURACY_500_PPM as u8,
         }),

--- a/examples/src/bin/ble_l2cap_central.rs
+++ b/examples/src/bin/ble_l2cap_central.rs
@@ -81,7 +81,7 @@ async fn main(spawner: Spawner) {
             source: raw::NRF_CLOCK_LF_SRC_RC as u8,
             rc_ctiv: 4,
             rc_temp_ctiv: 2,
-            accuracy: 7,
+            accuracy: raw::NRF_CLOCK_LF_ACCURACY_500_PPM as u8,
         }),
         conn_gap: Some(raw::ble_gap_conn_cfg_t {
             conn_count: 20,

--- a/examples/src/bin/ble_l2cap_peripheral.rs
+++ b/examples/src/bin/ble_l2cap_peripheral.rs
@@ -70,7 +70,7 @@ async fn main(spawner: Spawner) {
     let config = nrf_softdevice::Config {
         clock: Some(raw::nrf_clock_lf_cfg_t {
             source: raw::NRF_CLOCK_LF_SRC_RC as u8,
-            rc_ctiv: 4,
+            rc_ctiv: 16,
             rc_temp_ctiv: 2,
             accuracy: raw::NRF_CLOCK_LF_ACCURACY_500_PPM as u8,
         }),

--- a/examples/src/bin/ble_l2cap_peripheral.rs
+++ b/examples/src/bin/ble_l2cap_peripheral.rs
@@ -72,7 +72,7 @@ async fn main(spawner: Spawner) {
             source: raw::NRF_CLOCK_LF_SRC_RC as u8,
             rc_ctiv: 4,
             rc_temp_ctiv: 2,
-            accuracy: 7,
+            accuracy: raw::NRF_CLOCK_LF_ACCURACY_500_PPM as u8,
         }),
         conn_gap: Some(raw::ble_gap_conn_cfg_t {
             conn_count: 20,

--- a/examples/src/bin/ble_peripheral_onoff.rs
+++ b/examples/src/bin/ble_peripheral_onoff.rs
@@ -83,7 +83,7 @@ async fn main(spawner: Spawner) {
     let config = nrf_softdevice::Config {
         clock: Some(raw::nrf_clock_lf_cfg_t {
             source: raw::NRF_CLOCK_LF_SRC_RC as u8,
-            rc_ctiv: 4,
+            rc_ctiv: 16,
             rc_temp_ctiv: 2,
             accuracy: raw::NRF_CLOCK_LF_ACCURACY_500_PPM as u8,
         }),

--- a/examples/src/bin/ble_peripheral_onoff.rs
+++ b/examples/src/bin/ble_peripheral_onoff.rs
@@ -85,7 +85,7 @@ async fn main(spawner: Spawner) {
             source: raw::NRF_CLOCK_LF_SRC_RC as u8,
             rc_ctiv: 4,
             rc_temp_ctiv: 2,
-            accuracy: 7,
+            accuracy: raw::NRF_CLOCK_LF_ACCURACY_500_PPM as u8,
         }),
         conn_gap: Some(raw::ble_gap_conn_cfg_t {
             conn_count: 6,

--- a/examples/src/bin/ble_scan.rs
+++ b/examples/src/bin/ble_scan.rs
@@ -26,7 +26,7 @@ async fn main(spawner: Spawner) {
             source: raw::NRF_CLOCK_LF_SRC_RC as u8,
             rc_ctiv: 4,
             rc_temp_ctiv: 2,
-            accuracy: 7,
+            accuracy: raw::NRF_CLOCK_LF_ACCURACY_500_PPM as u8,
         }),
         conn_gap: Some(raw::ble_gap_conn_cfg_t {
             conn_count: 6,

--- a/examples/src/bin/ble_scan.rs
+++ b/examples/src/bin/ble_scan.rs
@@ -24,7 +24,7 @@ async fn main(spawner: Spawner) {
     let config = nrf_softdevice::Config {
         clock: Some(raw::nrf_clock_lf_cfg_t {
             source: raw::NRF_CLOCK_LF_SRC_RC as u8,
-            rc_ctiv: 4,
+            rc_ctiv: 16,
             rc_temp_ctiv: 2,
             accuracy: raw::NRF_CLOCK_LF_ACCURACY_500_PPM as u8,
         }),


### PR DESCRIPTION
The original value of `7` sets the accuracy to 20 ppm (`NRF_CLOCK_LF_ACCURACY_20_PPM`). However, the chip's internal RC oscillator has an accuracy of 500 ppm. I think this should be `NRF_CLOCK_LF_ACCURACY_500_PPM` (= `1`).