### PR TITLE
Fix calibration config value

### DIFF
--- a/examples/src/bin/ble_bas_peripheral_notify.rs
+++ b/examples/src/bin/ble_bas_peripheral_notify.rs
@@ -104,7 +104,7 @@ async fn main(spawner: Spawner) {
         clock: Some(raw::nrf_clock_lf_cfg_t {
             source: raw::NRF_CLOCK_LF_SRC_RC as u8,
             rc_ctiv: 16,
-            rc_temp_ctiv: 0,
+            rc_temp_ctiv: 2,
             accuracy: raw::NRF_CLOCK_LF_ACCURACY_500_PPM as u8,
         }),
         conn_gap: Some(raw::ble_gap_conn_cfg_t {


### PR DESCRIPTION
This change should have been in  #165. Sorry, I somehow overlooked it.

"For nRF52, the application must ensure calibration at least once every 8 seconds to ensure +/-500 ppm clock stability. The recommended configuration for `NRF_CLOCK_LF_SRC_RC` on nRF52 is `rc_ctiv=16` and `rc_temp_ctiv=2`. This will ensure calibration at least once every 8 seconds and for temperature changes of 0.5 degrees Celsius every 4 seconds." ([Nordic documentation](https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.s132.api.v7.3.0/structnrf__clock__lf__cfg__t.html))