### PR TITLE
feat: added nightly feature gate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,5 +25,7 @@ jobs:
 
       - name: Check fmt
         run: cargo fmt -- --check
-      - name: Build
+      - name: Build (nightly)
         run: ./ci.sh
+      - name: Build (stable)
+        run: ./ci-stable.sh

--- a/ci-stable.sh
+++ b/ci-stable.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# examples aren't build here because they require nightly rust
+
+
+# build with log/defmt combinations
+#=====================================
+
+cd nrf-softdevice
+
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,defmt
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,log
+
+
+# build softdevice+chip combinations (with all supported features enabled)
+# This htis each softdevice and each chip at least once.
+#================================================================================
+
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s112,nrf52805,ble-sec,ble-peripheral,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s113,nrf52810,ble-sec,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s122,nrf52833,ble-central,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s132,nrf52832,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52811,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52820,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+
+
+# build all feature combinations
+#==================================
+
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-l2cap
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-l2cap,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-l2cap,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-l2cap
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-l2cap,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-l2cap,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-l2cap,ble-gatt-client,ble-gatt-server
+
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,ble-l2cap-credit-wrokaround,ble-rssi
+
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-l2cap
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-l2cap,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-l2cap,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,ble-l2cap-credit-wrokaround,ble-rssi

--- a/ci-stable.sh
+++ b/ci-stable.sh
@@ -10,70 +10,70 @@ set -euxo pipefail
 
 cd nrf-softdevice
 
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,defmt
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,log
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,defmt
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,log
 
 
 # build softdevice+chip combinations (with all supported features enabled)
 # This htis each softdevice and each chip at least once.
 #================================================================================
 
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s112,nrf52805,ble-sec,ble-peripheral,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s113,nrf52810,ble-sec,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s122,nrf52833,ble-central,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s132,nrf52832,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52811,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52820,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s112,nrf52805,ble-sec,ble-peripheral,ble-gatt-client,ble-gatt-server
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s113,nrf52810,ble-sec,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s122,nrf52833,ble-central,ble-gatt-client,ble-gatt-server
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s132,nrf52832,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52811,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52820,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
 
 
 # build all feature combinations
 #==================================
 
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-gatt-client
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-l2cap
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-l2cap,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-l2cap,ble-gatt-client
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-gatt-server
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-gatt-client
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-gatt-client,ble-gatt-server
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-l2cap
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-l2cap,ble-gatt-server
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-l2cap,ble-gatt-client
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
 
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-gatt-client
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-l2cap
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-l2cap,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-l2cap,ble-gatt-client
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-gatt-server
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-gatt-client
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-gatt-client,ble-gatt-server
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-l2cap
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-l2cap,ble-gatt-server
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-l2cap,ble-gatt-client
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-l2cap,ble-gatt-client,ble-gatt-server
 
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-gatt-client
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,ble-l2cap-credit-wrokaround,ble-rssi
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-gatt-server
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-gatt-client
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-gatt-client,ble-gatt-server
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-server
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,ble-l2cap-credit-wrokaround,ble-rssi
 
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-gatt-client
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-l2cap
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-l2cap,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-l2cap,ble-gatt-client
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-gatt-server
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-gatt-client
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-gatt-client,ble-gatt-server
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-l2cap
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-l2cap,ble-gatt-server
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-l2cap,ble-gatt-client
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
 
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-gatt-client
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,ble-l2cap-credit-wrokaround,ble-rssi
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-gatt-server
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-gatt-client
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-gatt-client,ble-gatt-server
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-server
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,ble-l2cap-credit-wrokaround,ble-rssi

--- a/ci-stable.sh
+++ b/ci-stable.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# enable stable toolchain
+cp rust-toolchain-stable.toml rust-toolchain.toml
+
 set -euxo pipefail
 
 # examples aren't build here because they require nightly rust
@@ -10,70 +13,70 @@ set -euxo pipefail
 
 cd nrf-softdevice
 
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,defmt
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,log
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,defmt
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,log
 
 
 # build softdevice+chip combinations (with all supported features enabled)
 # This htis each softdevice and each chip at least once.
 #================================================================================
 
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s112,nrf52805,ble-sec,ble-peripheral,ble-gatt-client,ble-gatt-server
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s113,nrf52810,ble-sec,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s122,nrf52833,ble-central,ble-gatt-client,ble-gatt-server
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s132,nrf52832,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52811,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52820,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s112,nrf52805,ble-sec,ble-peripheral,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s113,nrf52810,ble-sec,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s122,nrf52833,ble-central,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s132,nrf52832,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52811,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52820,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
 
 
 # build all feature combinations
 #==================================
 
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-gatt-server
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-gatt-client
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-gatt-client,ble-gatt-server
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-l2cap
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-l2cap,ble-gatt-server
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-l2cap,ble-gatt-client
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-l2cap
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-l2cap,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-l2cap,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
 
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-gatt-server
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-gatt-client
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-gatt-client,ble-gatt-server
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-l2cap
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-l2cap,ble-gatt-server
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-l2cap,ble-gatt-client
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-l2cap
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-l2cap,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-l2cap,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-l2cap,ble-gatt-client,ble-gatt-server
 
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-gatt-server
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-gatt-client
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-gatt-client,ble-gatt-server
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-server
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,ble-l2cap-credit-wrokaround,ble-rssi
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,ble-l2cap-credit-wrokaround,ble-rssi
 
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-gatt-server
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-gatt-client
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-gatt-client,ble-gatt-server
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-l2cap
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-l2cap,ble-gatt-server
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-l2cap,ble-gatt-client
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-l2cap
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-l2cap,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-l2cap,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
 
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-gatt-server
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-gatt-client
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-gatt-client,ble-gatt-server
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-server
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
-cargo +stable build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,ble-l2cap-credit-wrokaround,ble-rssi
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,ble-l2cap-credit-wrokaround,ble-rssi

--- a/ci.sh
+++ b/ci.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# enable nightly toolchain
+cp rust-toolchain-nightly.toml rust-toolchain.toml
+
 set -euxo pipefail
 
 # build examples

--- a/ci.sh
+++ b/ci.sh
@@ -13,70 +13,70 @@ set -euxo pipefail
 
 cd nrf-softdevice
 
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,defmt
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,log
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,defmt
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,log
 
 
 # build softdevice+chip combinations (with all supported features enabled)
 # This htis each softdevice and each chip at least once.
 #================================================================================
 
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s112,nrf52805,ble-sec,ble-peripheral,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s113,nrf52810,ble-sec,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s122,nrf52833,ble-central,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s132,nrf52832,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52811,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52820,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s112,nrf52805,ble-sec,ble-peripheral,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s113,nrf52810,ble-sec,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s122,nrf52833,ble-central,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s132,nrf52832,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52811,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52820,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
 
 
 # build all feature combinations
 #==================================
 
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-gatt-client
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-l2cap
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-l2cap,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-l2cap,ble-gatt-client
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-peripheral
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-peripheral,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-peripheral,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-peripheral,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-peripheral,ble-l2cap
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-peripheral,ble-l2cap,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-peripheral,ble-l2cap,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
 
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-gatt-client
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-l2cap
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-l2cap,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-l2cap,ble-gatt-client
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-central
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-central,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-central,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-central,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-central,ble-l2cap
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-central,ble-l2cap,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-central,ble-l2cap,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-central,ble-l2cap,ble-gatt-client,ble-gatt-server
 
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-gatt-client
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,ble-l2cap-credit-wrokaround,ble-rssi
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-central,ble-peripheral
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-central,ble-peripheral,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-central,ble-peripheral,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-central,ble-peripheral,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-central,ble-peripheral,ble-l2cap
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,ble-l2cap-credit-wrokaround,ble-rssi
 
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-gatt-client
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-l2cap
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-l2cap,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-l2cap,ble-gatt-client
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-sec,ble-peripheral
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-sec,ble-peripheral,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-sec,ble-peripheral,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-sec,ble-peripheral,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-sec,ble-peripheral,ble-l2cap
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-sec,ble-peripheral,ble-l2cap,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-sec,ble-peripheral,ble-l2cap,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-sec,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
 
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-gatt-client
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,ble-l2cap-credit-wrokaround,ble-rssi
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-sec,ble-central,ble-peripheral
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features nightly,s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,ble-l2cap-credit-wrokaround,ble-rssi

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -27,7 +27,7 @@ cortex-m-rt = "0.7.0"
 defmt = "0.3"
 defmt-rtt = "0.4.0"
 panic-probe = { version = "0.3", features= ["print-defmt"] }
-nrf-softdevice = { version = "0.1.0", path = "../nrf-softdevice", features = ["defmt", "nrf52840", "s140", "ble-peripheral", "ble-central", "critical-section-impl"] }
+nrf-softdevice = { version = "0.1.0", path = "../nrf-softdevice", features = ["nightly", "defmt", "nrf52840", "s140", "ble-peripheral", "ble-central", "critical-section-impl"] }
 nrf-softdevice-s140 = { version = "0.1.1", path = "../nrf-softdevice-s140" }
 embedded-storage = "0.3.0"
 embedded-storage-async = "0.4.0"

--- a/nrf-softdevice-macro/Cargo.toml
+++ b/nrf-softdevice-macro/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
+[features]
+nightly = []
+
 [dependencies]
 syn = { version = "1.0.39", features = ["full", "extra-traits"] }
 quote = "1.0.7"

--- a/nrf-softdevice-macro/Cargo.toml
+++ b/nrf-softdevice-macro/Cargo.toml
@@ -5,9 +5,6 @@ authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
-[features]
-nightly = []
-
 [dependencies]
 syn = { version = "1.0.39", features = ["full", "extra-traits"] }
 quote = "1.0.7"

--- a/nrf-softdevice-macro/src/ctxt.rs
+++ b/nrf-softdevice-macro/src/ctxt.rs
@@ -1,0 +1,73 @@
+// nifty utility borrowed from serde :)
+// https://github.com/serde-rs/serde/blob/master/serde_derive/src/internals/ctxt.rs
+
+use std::cell::RefCell;
+use std::fmt::Display;
+use std::thread;
+
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+use syn;
+
+/// A type to collect errors together and format them.
+///
+/// Dropping this object will cause a panic. It must be consumed using `check`.
+///
+/// References can be shared since this type uses run-time exclusive mut checking.
+#[derive(Default)]
+pub struct Ctxt {
+    // The contents will be set to `None` during checking. This is so that checking can be
+    // enforced.
+    errors: RefCell<Option<Vec<syn::Error>>>,
+}
+
+impl Ctxt {
+    /// Create a new context object.
+    ///
+    /// This object contains no errors, but will still trigger a panic if it is not `check`ed.
+    pub fn new() -> Self {
+        Ctxt {
+            errors: RefCell::new(Some(Vec::new())),
+        }
+    }
+
+    /// Add an error to the context object with a tokenenizable object.
+    ///
+    /// The object is used for spanning in error messages.
+    pub fn error_spanned_by<A: ToTokens, T: Display>(&self, obj: A, msg: T) {
+        self.errors
+            .borrow_mut()
+            .as_mut()
+            .unwrap()
+            // Curb monomorphization from generating too many identical methods.
+            .push(syn::Error::new_spanned(obj.into_token_stream(), msg));
+    }
+
+    /// Add one of Syn's parse errors.
+    #[allow(unused)]
+    pub fn syn_error(&self, err: syn::Error) {
+        self.errors.borrow_mut().as_mut().unwrap().push(err);
+    }
+
+    /// Consume this object, producing a formatted error string if there are errors.
+    pub fn check(self) -> Result<(), TokenStream> {
+        let errors = self.errors.borrow_mut().take().unwrap();
+        match errors.len() {
+            0 => Ok(()),
+            _ => Err(to_compile_errors(errors)),
+        }
+    }
+}
+
+fn to_compile_errors(errors: Vec<syn::Error>) -> proc_macro2::TokenStream {
+    let compile_errors = errors.iter().map(syn::Error::to_compile_error);
+    quote!(#(#compile_errors)*)
+}
+
+impl Drop for Ctxt {
+    fn drop(&mut self) {
+        if !thread::panicking() && self.errors.borrow().is_some() {
+            panic!("forgot to check for errors");
+        }
+    }
+}

--- a/nrf-softdevice-macro/src/lib.rs
+++ b/nrf-softdevice-macro/src/lib.rs
@@ -48,10 +48,7 @@ pub fn gatt_server(_args: TokenStream, item: TokenStream) -> TokenStream {
     let struct_fields = match &mut struc.fields {
         syn::Fields::Named(n) => n,
         _ => {
-            let s = struc
-                .ident
-                .span()
-                .unwrap();
+            let s = struc.ident.span().unwrap();
 
             #[cfg(feature = "nightly")]
             s.error("gatt_server structs must have named fields, not tuples.")
@@ -146,10 +143,7 @@ pub fn gatt_service(args: TokenStream, item: TokenStream) -> TokenStream {
     let struct_fields = match &mut struc.fields {
         syn::Fields::Named(n) => n,
         _ => {
-            let s =struc
-                .ident
-                .span()
-                .unwrap();
+            let s = struc.ident.span().unwrap();
 
             #[cfg(feature = "nightly")]
             s.error("gatt_service structs must have named fields, not tuples.")
@@ -440,10 +434,7 @@ pub fn gatt_client(args: TokenStream, item: TokenStream) -> TokenStream {
     let struct_fields = match &mut struc.fields {
         syn::Fields::Named(n) => n,
         _ => {
-            let s = struc
-                .ident
-                .span()
-                .unwrap();
+            let s = struc.ident.span().unwrap();
 
             #[cfg(feature = "nightly")]
             s.error("gatt_client structs must have named fields, not tuples.")

--- a/nrf-softdevice-macro/src/lib.rs
+++ b/nrf-softdevice-macro/src/lib.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(feature = "nightly", feature(proc_macro_diagnostic))]
-
 extern crate proc_macro;
 
 use darling::FromMeta;
@@ -7,10 +5,11 @@ use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{format_ident, quote, quote_spanned};
 use syn::spanned::Spanned;
+
 use crate::ctxt::Ctxt;
 
-mod uuid;
 mod ctxt;
+mod uuid;
 
 use crate::uuid::Uuid;
 
@@ -44,9 +43,7 @@ struct Characteristic {
 
 #[proc_macro_attribute]
 pub fn gatt_server(_args: TokenStream, item: TokenStream) -> TokenStream {
-
     // Context for error reporting
-    #[cfg(not(feature = "nightly"))]
     let ctxt = Ctxt::new();
 
     let mut struc = syn::parse_macro_input!(item as syn::ItemStruct);
@@ -57,14 +54,7 @@ pub fn gatt_server(_args: TokenStream, item: TokenStream) -> TokenStream {
         _ => {
             let s = struc.ident;
 
-            #[cfg(not(feature = "nightly"))]
             ctxt.error_spanned_by(s, "gatt_server structs must have named fields, not tuples.");
-
-            #[cfg(feature = "nightly")]
-            s.span()
-                .unwrap()
-                .error("gatt_server structs must have named fields, not tuples.")
-                .emit();
 
             return TokenStream::new();
         }
@@ -135,14 +125,10 @@ pub fn gatt_server(_args: TokenStream, item: TokenStream) -> TokenStream {
         }
     };
 
-    #[cfg(not(feature = "nightly"))]
     match ctxt.check() {
         Ok(()) => result.into(),
-        Err(e) => e.into()
+        Err(e) => e.into(),
     }
-
-    #[cfg(feature = "nightly")]
-    result.into()
 }
 
 #[proc_macro_attribute]
@@ -150,7 +136,6 @@ pub fn gatt_service(args: TokenStream, item: TokenStream) -> TokenStream {
     let args = syn::parse_macro_input!(args as syn::AttributeArgs);
     let mut struc = syn::parse_macro_input!(item as syn::ItemStruct);
 
-    #[cfg(not(feature = "nightly"))]
     let ctxt = Ctxt::new();
 
     let args = match ServiceArgs::from_list(&args) {
@@ -168,14 +153,8 @@ pub fn gatt_service(args: TokenStream, item: TokenStream) -> TokenStream {
         _ => {
             let s = struc.ident;
 
-            #[cfg(not(feature = "nightly"))]
             ctxt.error_spanned_by(s, "gatt_service structs must have named fields, not tuples.");
 
-            #[cfg(feature = "nightly")]
-            s.span()
-                .unwrap()
-                .error("gatt_service structs must have named fields, not tuples.")
-                .emit();
             return TokenStream::new();
         }
     };
@@ -442,14 +421,10 @@ pub fn gatt_service(args: TokenStream, item: TokenStream) -> TokenStream {
             #code_event_enum
         }
     };
-    #[cfg(not(feature = "nightly"))]
     match ctxt.check() {
         Ok(()) => result.into(),
-        Err(e) => e.into()
+        Err(e) => e.into(),
     }
-
-    #[cfg(feature = "nightly")]
-    result.into()
 }
 
 #[proc_macro_attribute]
@@ -457,8 +432,6 @@ pub fn gatt_client(args: TokenStream, item: TokenStream) -> TokenStream {
     let args = syn::parse_macro_input!(args as syn::AttributeArgs);
     let mut struc = syn::parse_macro_input!(item as syn::ItemStruct);
 
-
-    #[cfg(not(feature = "nightly"))]
     let ctxt = Ctxt::new();
 
     let args = match ServiceArgs::from_list(&args) {
@@ -475,14 +448,8 @@ pub fn gatt_client(args: TokenStream, item: TokenStream) -> TokenStream {
         _ => {
             let s = struc.ident;
 
-            #[cfg(not(feature = "nightly"))]
             ctxt.error_spanned_by(s, "gatt_client structs must have named fields, not tuples.");
 
-            #[cfg(feature = "nightly")]
-            s.span()
-                .unwrap()
-                .error("gatt_client structs must have named fields, not tuples.")
-                .emit();
             return TokenStream::new();
         }
     };
@@ -706,12 +673,8 @@ pub fn gatt_client(args: TokenStream, item: TokenStream) -> TokenStream {
             #code_event_enum
         }
     };
-    #[cfg(not(feature = "nightly"))]
     match ctxt.check() {
         Ok(()) => result.into(),
-        Err(e) => e.into()
+        Err(e) => e.into(),
     }
-
-    #[cfg(feature = "nightly")]
-    result.into()
 }

--- a/nrf-softdevice-macro/src/lib.rs
+++ b/nrf-softdevice-macro/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_diagnostic)]
+#![cfg_attr(feature = "nightly", feature(proc_macro_diagnostic))]
 
 extern crate proc_macro;
 
@@ -48,12 +48,15 @@ pub fn gatt_server(_args: TokenStream, item: TokenStream) -> TokenStream {
     let struct_fields = match &mut struc.fields {
         syn::Fields::Named(n) => n,
         _ => {
-            struc
+            let s = struc
                 .ident
                 .span()
-                .unwrap()
-                .error("gatt_server structs must have named fields, not tuples.")
+                .unwrap();
+
+            #[cfg(feature = "nightly")]
+            s.error("gatt_server structs must have named fields, not tuples.")
                 .emit();
+
             return TokenStream::new();
         }
     };
@@ -143,11 +146,13 @@ pub fn gatt_service(args: TokenStream, item: TokenStream) -> TokenStream {
     let struct_fields = match &mut struc.fields {
         syn::Fields::Named(n) => n,
         _ => {
-            struc
+            let s =struc
                 .ident
                 .span()
-                .unwrap()
-                .error("gatt_service structs must have named fields, not tuples.")
+                .unwrap();
+
+            #[cfg(feature = "nightly")]
+            s.error("gatt_service structs must have named fields, not tuples.")
                 .emit();
             return TokenStream::new();
         }
@@ -435,11 +440,13 @@ pub fn gatt_client(args: TokenStream, item: TokenStream) -> TokenStream {
     let struct_fields = match &mut struc.fields {
         syn::Fields::Named(n) => n,
         _ => {
-            struc
+            let s = struc
                 .ident
                 .span()
-                .unwrap()
-                .error("gatt_client structs must have named fields, not tuples.")
+                .unwrap();
+
+            #[cfg(feature = "nightly")]
+            s.error("gatt_client structs must have named fields, not tuples.")
                 .emit();
             return TokenStream::new();
         }

--- a/nrf-softdevice/Cargo.toml
+++ b/nrf-softdevice/Cargo.toml
@@ -32,6 +32,8 @@ ble-sec = []
 
 critical-section-impl = ["critical-section/restore-state-bool"]
 
+nightly = ["nrf-softdevice-macro/nightly"]
+
 # Workaround l2cap credit bug. If set, infinite credits are issued
 # to the peer in batches. The `credits` config when establishing the channel is ignored.
 # https://devzone.nordicsemi.com/f/nordic-q-a/81894/s140-7-3-0-softdevice-assertion-failed-at-pc-0xa806-using-l2cap

--- a/nrf-softdevice/Cargo.toml
+++ b/nrf-softdevice/Cargo.toml
@@ -32,7 +32,7 @@ ble-sec = []
 
 critical-section-impl = ["critical-section/restore-state-bool"]
 
-nightly = []
+nightly = ["embedded-storage-async"]
 
 # Workaround l2cap credit bug. If set, infinite credits are issued
 # to the peer in batches. The `credits` config when establishing the channel is ignored.
@@ -55,7 +55,7 @@ heapless = "0.7.1"
 fixed = "1.5.0"
 futures = { version = "0.3.17", default-features = false }
 embedded-storage = "0.3.0"
-embedded-storage-async = "0.4.0"
+embedded-storage-async = { version = "0.4.0", optional = true }
 
 nrf52805-pac  = { version = "0.12.0", features = ["rt"], optional = true }
 nrf52810-pac  = { version = "0.12.0", features = ["rt"], optional = true }

--- a/nrf-softdevice/Cargo.toml
+++ b/nrf-softdevice/Cargo.toml
@@ -32,7 +32,7 @@ ble-sec = []
 
 critical-section-impl = ["critical-section/restore-state-bool"]
 
-nightly = ["nrf-softdevice-macro/nightly"]
+nightly = []
 
 # Workaround l2cap credit bug. If set, infinite credits are issued
 # to the peer in batches. The `credits` config when establishing the channel is ignored.

--- a/nrf-softdevice/Cargo.toml
+++ b/nrf-softdevice/Cargo.toml
@@ -32,7 +32,7 @@ ble-sec = []
 
 critical-section-impl = ["critical-section/restore-state-bool"]
 
-nightly = ["embedded-storage-async"]
+nightly = ["dep:embedded-storage-async"]
 
 # Workaround l2cap credit bug. If set, infinite credits are issued
 # to the peer in batches. The `credits` config when establishing the channel is ignored.

--- a/nrf-softdevice/src/flash.rs
+++ b/nrf-softdevice/src/flash.rs
@@ -87,6 +87,7 @@ impl ReadNorFlash for Flash {
     }
 }
 
+#[cfg(feature = "nightly")]
 impl AsyncReadNorFlash for Flash {
     const READ_SIZE: usize = 1;
 
@@ -99,6 +100,7 @@ impl AsyncReadNorFlash for Flash {
     }
 }
 
+#[cfg(feature = "nightly")]
 impl AsyncNorFlash for Flash {
     const WRITE_SIZE: usize = 4;
     const ERASE_SIZE: usize = 4096;

--- a/nrf-softdevice/src/flash.rs
+++ b/nrf-softdevice/src/flash.rs
@@ -4,7 +4,6 @@ use core::sync::atomic::{AtomicBool, Ordering};
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::signal::Signal;
 use embedded_storage::nor_flash::{ErrorType, NorFlashError, NorFlashErrorKind, ReadNorFlash};
-
 #[cfg(feature = "nightly")]
 use embedded_storage_async::nor_flash::{NorFlash as AsyncNorFlash, ReadNorFlash as AsyncReadNorFlash};
 

--- a/nrf-softdevice/src/flash.rs
+++ b/nrf-softdevice/src/flash.rs
@@ -4,6 +4,8 @@ use core::sync::atomic::{AtomicBool, Ordering};
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::signal::Signal;
 use embedded_storage::nor_flash::{ErrorType, NorFlashError, NorFlashErrorKind, ReadNorFlash};
+
+#[cfg(feature = "nightly")]
 use embedded_storage_async::nor_flash::{NorFlash as AsyncNorFlash, ReadNorFlash as AsyncReadNorFlash};
 
 use crate::util::DropBomb;

--- a/nrf-softdevice/src/lib.rs
+++ b/nrf-softdevice/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
-#![feature(async_fn_in_trait)]
-#![feature(impl_trait_projections)]
+#![cfg_attr(feature = "nightly", feature(async_fn_in_trait))]
+#![cfg_attr(feature = "nightly", feature(impl_trait_projections))]
 #![allow(incomplete_features)]
 
 pub(crate) mod util;

--- a/rust-toolchain-nightly.toml
+++ b/rust-toolchain-nightly.toml
@@ -1,0 +1,13 @@
+# Before upgrading check that everything is available on all tier1 targets here:
+# https://rust-lang.github.io/rustup-components-history
+[toolchain]
+channel = "nightly-2022-11-22"
+components = [ "rust-src", "rustfmt" ]
+targets = [
+    "thumbv7em-none-eabi",
+    "thumbv7m-none-eabi",
+    "thumbv6m-none-eabi",
+    "thumbv7em-none-eabihf",
+    "thumbv8m.main-none-eabihf",
+    "wasm32-unknown-unknown",
+]

--- a/rust-toolchain-stable.toml
+++ b/rust-toolchain-stable.toml
@@ -1,0 +1,13 @@
+# Before upgrading check that everything is available on all tier1 targets here:
+# https://rust-lang.github.io/rustup-components-history
+[toolchain]
+channel = "stable"
+components = [ "rust-src", "rustfmt" ]
+targets = [
+    "thumbv7em-none-eabi",
+    "thumbv7m-none-eabi",
+    "thumbv6m-none-eabi",
+    "thumbv7em-none-eabihf",
+    "thumbv8m.main-none-eabihf",
+    "wasm32-unknown-unknown",
+]


### PR DESCRIPTION
This should enable the nrf-softdevice crate to be used on stable rust.
Note that the only tests I performed are building it with and without the nightly feature flag. So please do double-check that I didn't blow anything up.
A non-async flash write implementation might also be a good idea. I have one, but it's not really production ready. Basically just the async one, but ripped apart without the async stuff. Do tell whether I should add that.