### PR TITLE
feat(portal): made portal usable from interrupts

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ The SoftDevice does time-critical radio processing at high priorities. If its ti
 These mistakes WILL cause "assertion failed" errors, 100% guaranteed. If you do these only "a little bit", such as disabling all interrupts but for very short periods of time only, things may appear to work, but you will get "assertion failed" errors after hours
 of running. Make sure to follow them to the letter.
 
+The Softdevice Driver (e.g. `Softdevice::run()`) can't be used from interrupts by default. However, the 
+`usable-from-interrupts` feature enables this functionality. To use this, a `critical-section` implementation is required.
+This crate's internal implementation (`critical-section-impl` feature) is recommended, but other implementations that are Softdevice-compatible should also work.
+
 ### Critical sections
 
 Interrupts for certain peripherals and SWI/EGUs are [reserved for the SoftDevice](https://infocenter.nordicsemi.com/topic/sds_s140/SDS/s1xx/sd_resource_reqs/hw_block_interrupt_vector.html?cp=4_7_4_0_6_0). Interrupt handlers for them are reserved by the softdevice, the handlers in your application won't be called.

--- a/README.md
+++ b/README.md
@@ -129,9 +129,8 @@ The SoftDevice does time-critical radio processing at high priorities. If its ti
 These mistakes WILL cause "assertion failed" errors, 100% guaranteed. If you do these only "a little bit", such as disabling all interrupts but for very short periods of time only, things may appear to work, but you will get "assertion failed" errors after hours
 of running. Make sure to follow them to the letter.
 
-The Softdevice Driver (e.g. `Softdevice::run()`) can't be used from interrupts by default. However, the 
-`usable-from-interrupts` feature enables this functionality. To use this, a `critical-section` implementation is required.
-This crate's internal implementation (`critical-section-impl` feature) is recommended, but other implementations that are Softdevice-compatible should also work.
+The Softdevice Driver (e.g. `Softdevice::run()`) cannot be used from interrupts by default. However, the `usable-from-interrupts` feature enables this functionality. To use this feature, a `critical-section` implementation is required.
+This crate's internal implementation (`critical-section-impl` feature) is recommended, but other Softdevice-compatible implementations should also work.
 
 ### Critical sections
 

--- a/nrf-softdevice/Cargo.toml
+++ b/nrf-softdevice/Cargo.toml
@@ -32,7 +32,7 @@ ble-sec = []
 
 critical-section-impl = ["critical-section/restore-state-bool"]
 
-usable-from-interrupts = [ "critical-section-impl" ]
+usable-from-interrupts = []
 
 nightly = ["dep:embedded-storage-async"]
 

--- a/nrf-softdevice/Cargo.toml
+++ b/nrf-softdevice/Cargo.toml
@@ -32,6 +32,8 @@ ble-sec = []
 
 critical-section-impl = ["critical-section/restore-state-bool"]
 
+usable-from-interrupts = [ "critical-section-impl" ]
+
 nightly = ["dep:embedded-storage-async"]
 
 # Workaround l2cap credit bug. If set, infinite credits are issued

--- a/nrf-softdevice/src/util/drop_bomb.rs
+++ b/nrf-softdevice/src/util/drop_bomb.rs
@@ -5,10 +5,12 @@ pub struct DropBomb {
 }
 
 impl DropBomb {
+    #[allow(unused)]
     pub fn new() -> Self {
         Self { _private: () }
     }
 
+    #[allow(unused)]
     pub fn defuse(self) {
         mem::forget(self)
     }

--- a/nrf-softdevice/src/util/portal.rs
+++ b/nrf-softdevice/src/util/portal.rs
@@ -32,12 +32,6 @@ impl<T> Portal<T> {
     }
 
     pub fn call(&self, val: T) -> bool {
-        // Possible Improvement: Using the RefCell mutable borrow, it should be possible
-        // to prevent reentrant calling completely. My idea for this:
-        // Obtain a mutable reference at the start of the method, and then give it to the
-        // closure. Rust will gatekeep the function until the mutable reference disappears
-        // at the end of the closure.
-
         self.state.lock(|state| {
             let mut state = state.borrow_mut();
             if let Some(ptr) = state.0 {
@@ -86,7 +80,6 @@ impl<T> Portal<T> {
                 _ => unreachable!(),
             };
 
-            // Set state to Running while running the function to avoid reentrancy.
 
             if let Some(res) = func(val) {
                 unsafe {

--- a/nrf-softdevice/src/util/portal.rs
+++ b/nrf-softdevice/src/util/portal.rs
@@ -80,7 +80,6 @@ impl<T> Portal<T> {
             });
         });
 
-        // safety: this runs from thread mode
         self.state.lock(|state| {
             let mut state = state.borrow_mut();
             match *state {
@@ -138,7 +137,6 @@ impl<T> Portal<T> {
             });
         });
 
-        // safety: this runs from thread mode
         self.state.lock(|state| {
             let mut state = state.borrow_mut();
             match *state {

--- a/nrf-softdevice/src/util/portal.rs
+++ b/nrf-softdevice/src/util/portal.rs
@@ -42,6 +42,12 @@ impl<T> Portal<T> {
             State::Waiting(func) => Some(func),
         });
 
+        // Possible Improvement: Using the RefCell mutable borrow, it should be possible
+        // to prevent reentrant calling completely. My idea for this:
+        // Obtain a mutable reference at the start of the method, and then give it to the
+        // closure. Rust will gatekeep the function until the mutable reference disappears
+        // at the end of the closure.
+
         // re-entrant calling possible here. Acceptable because Portal::call() panics.
 
         if let Some(ptr) = maybe_func {
@@ -52,8 +58,8 @@ impl<T> Portal<T> {
     }
 
     pub async fn wait_once<'a, R, F>(&'a self, mut func: F) -> R
-        where
-            F: FnMut(T) -> R + 'a,
+    where
+        F: FnMut(T) -> R + 'a,
     {
         let signal = Signal::<CriticalSectionRawMutex, _>::new();
         let mut result: MaybeUninit<R> = MaybeUninit::uninit();
@@ -97,8 +103,8 @@ impl<T> Portal<T> {
 
     #[allow(unused)]
     pub async fn wait_many<'a, R, F>(&'a self, mut func: F) -> R
-        where
-            F: FnMut(T) -> Option<R> + 'a,
+    where
+        F: FnMut(T) -> Option<R> + 'a,
     {
         let signal = Signal::<CriticalSectionRawMutex, _>::new();
         let mut result: MaybeUninit<R> = MaybeUninit::uninit();

--- a/nrf-softdevice/src/util/portal.rs
+++ b/nrf-softdevice/src/util/portal.rs
@@ -77,7 +77,7 @@ impl<T> Portal<T> {
         let signal = Signal::<CriticalSectionRawMutex, _>::new();
         let mut result: MaybeUninit<R> = MaybeUninit::uninit();
 
-        let mut call_func = |val: T, state: &mut State<T>| unsafe {
+        let call_func = |val: T, state: &mut State<T>| unsafe {
             result.as_mut_ptr().write(func(val));
 
             signal.signal(());
@@ -89,7 +89,7 @@ impl<T> Portal<T> {
         // If the future gets cancelled from the outside, this gets dropped,
         // and resets the state of the portal to None
         let _bomb = OnDrop::new(|| {
-            self.state.lock(|mut state| *(state.borrow_mut()) = State(None));
+            self.state.lock(|state| *(state.borrow_mut()) = State(None));
         });
 
         self.set_function_pointer(call_func);

--- a/nrf-softdevice/src/util/portal.rs
+++ b/nrf-softdevice/src/util/portal.rs
@@ -1,16 +1,19 @@
-use core::cell::UnsafeCell;
-use core::future::Future;
+use core::cell::RefCell;
 use core::mem;
 use core::mem::MaybeUninit;
 
-use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::blocking_mutex::raw::{CriticalSectionRawMutex, ThreadModeRawMutex};
 use embassy_sync::signal::Signal;
+use embassy_sync::blocking_mutex::Mutex;
 
 use crate::util::OnDrop;
 
 /// Utility to call a closure across tasks.
 pub struct Portal<T> {
-    state: UnsafeCell<State<T>>,
+    #[cfg(feature = "usable-from-interrupts")]
+    state: Mutex<CriticalSectionRawMutex, RefCell<State<T>>>,
+    #[cfg(not(feature = "usable-from-interrupts"))]
+    state: Mutex<ThreadModeRawMutex, RefCell<State<T>>>,
 }
 
 enum State<T> {
@@ -21,139 +24,150 @@ enum State<T> {
 }
 
 unsafe impl<T> Send for Portal<T> {}
-unsafe impl<T> Sync for Portal<T> {}
 
+unsafe impl<T> Sync for Portal<T> {}  // NOT TRUE!
+
+#[cfg(not(feature = "usable-from-interrupts"))]
 fn assert_thread_mode() {
     assert!(
         cortex_m::peripheral::SCB::vect_active() == cortex_m::peripheral::scb::VectActive::ThreadMode,
-        "portals are not usable from interrupts"
+        "portals are not usable from interrupts. Activate the 'usable-from-interrupts' feature to allow this."
     );
 }
 
 impl<T> Portal<T> {
     pub const fn new() -> Self {
         Self {
-            state: UnsafeCell::new(State::None),
+            state: Mutex::new(RefCell::new(State::None)),
         }
     }
 
     pub fn call(&self, val: T) -> bool {
+        #[cfg(not(feature = "usable-from-interrupts"))]
         assert_thread_mode();
-
-        // safety: this runs from thread mode
-        unsafe {
-            match *self.state.get() {
-                State::None => false,
-                State::Done => false,
-                State::Running => panic!("Portall::call() called reentrantly"),
+        let maybe_func = self.state.lock(|state| {
+            match *state.borrow() {
+                State::None => None,
+                State::Done => None,
+                State::Running => panic!("Portal::call() called reentrantly"),
                 State::Waiting(func) => {
-                    (*func)(val);
-                    true
+                    Some(func)
                 }
             }
+        });
+
+        // re-entrant calling possible here. Acceptable because Portal::call() panics.
+
+        if let Some(ptr) = maybe_func {
+            // Safety: This is transmuted from a FnMut, and therefore valid
+            unsafe { (*ptr)(val) };
         }
+        true
     }
 
-    pub fn wait_once<'a, R, F>(&'a self, mut func: F) -> impl Future<Output = R> + 'a
-    where
-        F: FnMut(T) -> R + 'a,
+    pub async fn wait_once<'a, R, F>(&'a self, mut func: F) -> R
+        where
+            F: FnMut(T) -> R + 'a,
     {
+        #[cfg(not(feature = "usable-from-interrupts"))]
         assert_thread_mode();
+        let signal = Signal::<CriticalSectionRawMutex, _>::new();
+        let mut result: MaybeUninit<R> = MaybeUninit::uninit();
 
-        async move {
-            let signal = Signal::<CriticalSectionRawMutex, _>::new();
-            let mut result: MaybeUninit<R> = MaybeUninit::uninit();
-            let mut call_func = |val: T| unsafe {
-                let state = &mut *self.state.get();
-
+        let mut call_func = |val: T| unsafe {
+            self.state.lock(|state| {
+                let mut state = state.borrow_mut();
                 // Set state to Running while running the function to avoid reentrancy.
                 *state = State::Running;
                 result.as_mut_ptr().write(func(val));
 
                 *state = State::Done;
                 signal.signal(());
-            };
+            });
+        };
 
-            let func_ptr: *mut dyn FnMut(T) = &mut call_func as _;
-            let func_ptr: *mut dyn FnMut(T) = unsafe { mem::transmute(func_ptr) };
+        let func_ptr: *mut dyn FnMut(T) = &mut call_func as _;
+        let func_ptr: *mut dyn FnMut(T) = unsafe { mem::transmute(func_ptr) };
 
-            let _bomb = OnDrop::new(|| unsafe {
-                let state = &mut *self.state.get();
+
+        let _bomb = OnDrop::new(|| {
+            self.state.lock(|state| {
+                let mut state = state.borrow_mut();
                 *state = State::None;
             });
+        });
 
-            // safety: this runs from thread mode
-            unsafe {
-                let state = &mut *self.state.get();
-                match state {
-                    State::None => {}
-                    _ => panic!("Multiple tasks waiting on same portal"),
-                }
-                *state = State::Waiting(func_ptr);
+        // safety: this runs from thread mode
+        self.state.lock(|state| {
+            let mut state = state.borrow_mut();
+            match *state {
+                State::None => {}
+                _ => panic!("Multiple tasks waiting on same portal"),
             }
+            *state = State::Waiting(func_ptr);
+        });
 
-            signal.wait().await;
+        signal.wait().await;
 
-            unsafe { result.assume_init() }
-            // dropbomb sets self.state = None
-        }
+        unsafe { result.assume_init() }
+        // dropbomb sets self.state = None
     }
 
     #[allow(unused)]
-    pub fn wait_many<'a, R, F>(&'a self, mut func: F) -> impl Future<Output = R> + 'a
-    where
-        F: FnMut(T) -> Option<R> + 'a,
+    pub async fn wait_many<'a, R, F>(&'a self, mut func: F) -> R
+        where
+            F: FnMut(T) -> Option<R> + 'a,
     {
+        #[cfg(not(feature = "usable-from-interrupts"))]
         assert_thread_mode();
+        let signal = Signal::<CriticalSectionRawMutex, _>::new();
+        let mut result: MaybeUninit<R> = MaybeUninit::uninit();
+        let mut call_func = |val: T| {
+            self.state.lock(|state| {
+                let mut state = state.borrow_mut();
 
-        async move {
-            let signal = Signal::<CriticalSectionRawMutex, _>::new();
-            let mut result: MaybeUninit<R> = MaybeUninit::uninit();
-            let mut call_func = |val: T| {
-                unsafe {
-                    let state = &mut *self.state.get();
-
-                    let func_ptr = match *state {
-                        State::Waiting(p) => p,
-                        _ => unreachable!(),
-                    };
-
-                    // Set state to Running while running the function to avoid reentrancy.
-                    *state = State::Running;
-
-                    *state = match func(val) {
-                        None => State::Waiting(func_ptr),
-                        Some(res) => {
-                            result.as_mut_ptr().write(res);
-                            signal.signal(());
-                            State::Done
-                        }
-                    };
+                let func_ptr = match *state {
+                    State::Waiting(p) => p,
+                    _ => unreachable!(),
                 };
-            };
 
-            let func_ptr: *mut dyn FnMut(T) = &mut call_func as _;
-            let func_ptr: *mut dyn FnMut(T) = unsafe { mem::transmute(func_ptr) };
+                // Set state to Running while running the function to avoid reentrancy.
+                *state = State::Running;
 
-            let _bomb = OnDrop::new(|| unsafe {
-                let state = &mut *self.state.get();
+                *state = match func(val) {
+                    None => State::Waiting(func_ptr),
+                    Some(res) => {
+                        unsafe { result.as_mut_ptr().write(res); }
+                        signal.signal(());
+                        State::Done
+                    }
+                };
+            });
+        };
+
+        let func_ptr: *mut dyn FnMut(T) = &mut call_func as _;
+        let func_ptr: *mut dyn FnMut(T) = unsafe { mem::transmute(func_ptr) };
+
+        let _bomb = OnDrop::new(|| {
+            self.state.lock(|state| {
+                let mut state = state.borrow_mut();
                 *state = State::None;
             });
+        });
 
-            // safety: this runs from thread mode
-            unsafe {
-                let state = &mut *self.state.get();
-                match *state {
-                    State::None => {}
-                    _ => panic!("Multiple tasks waiting on same portal"),
-                }
-                *state = State::Waiting(func_ptr);
+        // safety: this runs from thread mode
+        self.state.lock(|state| {
+            let mut state = state.borrow_mut();
+            match *state {
+                State::None => {}
+                _ => panic!("Multiple tasks waiting on same portal"),
             }
+            *state = State::Waiting(func_ptr);
+        });
 
-            signal.wait().await;
+        signal.wait().await;
 
-            unsafe { result.assume_init() }
-            // dropbomb sets self.state = None
-        }
+        unsafe { result.assume_init() }
+        // dropbomb sets self.state = None
     }
 }


### PR DESCRIPTION
This allows using the Portal from interrupts by locking all important resources with a `CriticalSectionRawMutex` if that is desired. Switches to a `ThreadModeRawMutex` automatically when the feature `usable-from-interrupts` is not enabled. When using the portal (or the softdevice overall) from interrupts without enabling it explicitly, a helpful message that reminds the user to activate the feature if they so desire is displayed.