### PR TITLE
Added Security Modes and improved Error Handling in GATT macros

### DIFF
--- a/nrf-softdevice-macro/src/lib.rs
+++ b/nrf-softdevice-macro/src/lib.rs
@@ -10,8 +10,8 @@ use crate::ctxt::Ctxt;
 use crate::security_mode::SecurityMode;
 
 mod ctxt;
-mod uuid;
 mod security_mode;
+mod uuid;
 
 use crate::uuid::Uuid;
 
@@ -132,9 +132,7 @@ pub fn gatt_server(_args: TokenStream, item: TokenStream) -> TokenStream {
 
     match ctxt.check() {
         Ok(()) => result.into(),
-        Err(e) => {
-            e.into()
-        }
+        Err(e) => e.into(),
     }
 }
 
@@ -200,7 +198,10 @@ pub fn gatt_service(args: TokenStream, item: TokenStream) -> TokenStream {
 
     if let Some(err) = err {
         let desc = err.to_string();
-        ctxt.error_spanned_by(err.write_errors(), format!("Parsing characteristics was unsuccessful: {}", desc));
+        ctxt.error_spanned_by(
+            err.write_errors(),
+            format!("Parsing characteristics was unsuccessful: {}", desc),
+        );
         return ctxt.check().unwrap_err().into();
     }
 
@@ -239,8 +240,9 @@ pub fn gatt_service(args: TokenStream, item: TokenStream) -> TokenStream {
         let security = if let Some(security) = ch.args.security {
             let security_inner = security.to_token_stream();
             quote!(attr = attr.read_security(#security_inner).write_security(#security_inner))
-        } else { quote!() };
-
+        } else {
+            quote!()
+        };
 
         fields.push(syn::Field {
             ident: Some(value_handle.clone()),

--- a/nrf-softdevice-macro/src/security_mode.rs
+++ b/nrf-softdevice-macro/src/security_mode.rs
@@ -1,0 +1,48 @@
+use darling::{Error, FromMeta};
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum SecurityMode {
+    NoAccess,
+    Open,
+    JustWorks,
+    Mitm,
+    LescMitm,
+    Signed,
+    SignedMitm,
+}
+
+impl FromMeta for SecurityMode {
+    fn from_string(value: &str) -> darling::Result<Self> {
+        match value.trim().to_lowercase().as_str() {
+            "noaccess" => Ok(SecurityMode::NoAccess),
+            "open" => Ok(SecurityMode::Open),
+            "justworks" => Ok(SecurityMode::JustWorks),
+            "mitm" => Ok(SecurityMode::Mitm),
+            "lescmitm" => Ok(SecurityMode::LescMitm),
+            "signed" => Ok(SecurityMode::Signed),
+            "signedmitm" => Ok(SecurityMode::SignedMitm),
+            _ => Err(Error::unknown_value(format!(
+                "SecurityMode {} is invalid. Expected one of: NoAccess, Open, JustWorks, Mitm, LescMitm, Signed, SignedMitm",
+                value)
+                .as_str())),
+        }
+    }
+}
+
+impl ToTokens for SecurityMode {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let literal = match self {
+            SecurityMode::NoAccess => quote!(NoAccess),
+            SecurityMode::Open => quote!(Open),
+            SecurityMode::JustWorks => quote!(JustWorks),
+            SecurityMode::Mitm => quote!(Mitm),
+            SecurityMode::LescMitm => quote!(LescMitm),
+            SecurityMode::Signed => quote!(Signed),
+            SecurityMode::SignedMitm => quote!(SignedMitm),
+        };
+        tokens.extend(quote!(::nrf_softdevice::ble::SecurityMode::#literal))
+    }
+}


### PR DESCRIPTION
Security Modes work like this:
```rust
#[nrf_softdevice::gatt_service(uuid = "180f")]
struct BatteryService {
    #[characteristic(uuid = "2a19", read, notify, security = "JustWorks")]
    battery_level: u8,
    #[characteristic(uuid = "something-else", read, notify, security = "NoAccess")]
    other_characteristic: u8,
    #[characteristic(uuid = "something-else", read)]
    no_mode_means_default: u8,
}
```