### PR TITLE
fix(gatt_traits): fixed gatt server crashing at writes to [u8; N] with len < N

### DIFF
--- a/nrf-softdevice/src/ble/gatt_traits.rs
+++ b/nrf-softdevice/src/ble/gatt_traits.rs
@@ -107,7 +107,13 @@ impl<const N: usize> GattValue for [u8; N] {
     const MAX_SIZE: usize = N;
 
     fn from_gatt(data: &[u8]) -> Self {
-        unwrap!(data.try_into())
+        if data.len() < Self::MAX_SIZE {
+            let mut actual = [0; N];
+            actual[..data.len()].copy_from_slice(data);
+            actual
+        } else {
+            unwrap!(data.try_into())
+        }
     }
 
     fn to_gatt(&self) -> &[u8] {


### PR DESCRIPTION
```rust
#[characteristic(uuid = "...", write)]
some_characteristic: [u8; 4]
```
will fail whenever the written value is smaller than four octets, and it will not do so gracefully, but instead panic directly.
This PR fixes this problem. New behavior:
* Writing `[0x10, 0x20, 0x30, 0x40]` via Bluetooth will set `some_characteristic` to that exact value
* Writing `[0x10, 0x20]` via Bluetooth will set `some_characteristic` to `[0x10, 0x20, 0x00, 0x00]`, whereby all places that aren't set are zeroed