### PR TITLE
Allow processing soc events and ble events in separate tasks

### DIFF
--- a/nrf-softdevice/Cargo.toml
+++ b/nrf-softdevice/Cargo.toml
@@ -51,6 +51,7 @@ critical-section = { version = "1.0", optional = true }
 
 num_enum = { version = "0.6.1", default-features = false }
 embassy-sync = { version = "0.2.0" }
+embassy-futures = { version = "0.1.0" }
 cortex-m = "0.7.2"
 cortex-m-rt = ">=0.6.15,<0.8"
 heapless = "0.7.1"


### PR DESCRIPTION
This change splits the run function into two: one for processing BLE events and one for processing SoC events, while keeping the existing API joining the two futures. 

With this change, GATT server closures, which are invoked by the ble event task, can use the flash peripheral successfully (which relies on soc events for completion) by running the soc event task on a separate executor (although I'm not entirely sure if that's safe! It seem to work)