### PR TITLE
Add Proc Macro for Generating Adv/Scan Data

### DIFF
--- a/examples/src/bin/ble_advertise.rs
+++ b/examples/src/bin/ble_advertise.rs
@@ -10,7 +10,7 @@ use core::mem;
 use defmt::{info, *};
 use embassy_executor::Spawner;
 use nrf_softdevice::ble::peripheral;
-use nrf_softdevice::{generate_adv_data, generate_scan_data, raw, Softdevice};
+use nrf_softdevice::{generate_adv_data, raw, Softdevice};
 
 const ADV_DATA: &[u8] = generate_adv_data! {
     flags: (GeneralDiscovery),
@@ -20,7 +20,7 @@ const ADV_DATA: &[u8] = generate_adv_data! {
 
 // but we can put it in the scan data
 // so the full name is visible once connected
-const SCAN_DATA: &[u8] = generate_scan_data! {
+const SCAN_DATA: &[u8] = generate_adv_data! {
     full_name: "Hello, Rust!"
 };
 

--- a/examples/src/bin/ble_bas_peripheral.rs
+++ b/examples/src/bin/ble_bas_peripheral.rs
@@ -10,7 +10,7 @@ use core::mem;
 use defmt::{info, *};
 use embassy_executor::Spawner;
 use nrf_softdevice::ble::{gatt_server, peripheral};
-use nrf_softdevice::{generate_adv_data, generate_scan_data, raw, Softdevice};
+use nrf_softdevice::{generate_adv_data, raw, Softdevice};
 
 const ADV_DATA: &[u8] = generate_adv_data! {
     flags: (GeneralDiscovery),
@@ -18,7 +18,7 @@ const ADV_DATA: &[u8] = generate_adv_data! {
     short_name: "HelloRust"
 };
 
-const SCAN_DATA: &[u8] = generate_scan_data! {
+const SCAN_DATA: &[u8] = generate_adv_data! {
     services: Complete16(HealthThermometer)
 };
 

--- a/examples/src/bin/ble_bas_peripheral.rs
+++ b/examples/src/bin/ble_bas_peripheral.rs
@@ -10,7 +10,17 @@ use core::mem;
 use defmt::{info, *};
 use embassy_executor::Spawner;
 use nrf_softdevice::ble::{gatt_server, peripheral};
-use nrf_softdevice::{raw, Softdevice};
+use nrf_softdevice::{generate_adv_data, generate_scan_data, raw, Softdevice};
+
+const ADV_DATA: &[u8] = generate_adv_data! {
+    flags: (GeneralDiscovery),
+    services: Complete16(HealthThermometer),
+    short_name: "HelloRust"
+};
+
+const SCAN_DATA: &[u8] = generate_scan_data! {
+    services: Complete16(HealthThermometer)
+};
 
 #[embassy_executor::task]
 async fn softdevice_task(sd: &'static Softdevice) -> ! {
@@ -73,20 +83,12 @@ async fn main(spawner: Spawner) {
     let server = unwrap!(Server::new(sd));
     unwrap!(spawner.spawn(softdevice_task(sd)));
 
-    #[rustfmt::skip]
-    let adv_data = &[
-        0x02, 0x01, raw::BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE as u8,
-        0x03, 0x03, 0x09, 0x18,
-        0x0a, 0x09, b'H', b'e', b'l', b'l', b'o', b'R', b'u', b's', b't',
-    ];
-    #[rustfmt::skip]
-    let scan_data = &[
-        0x03, 0x03, 0x09, 0x18,
-    ];
-
     loop {
         let config = peripheral::Config::default();
-        let adv = peripheral::ConnectableAdvertisement::ScannableUndirected { adv_data, scan_data };
+        let adv = peripheral::ConnectableAdvertisement::ScannableUndirected {
+            adv_data: ADV_DATA,
+            scan_data: SCAN_DATA,
+        };
         let conn = unwrap!(peripheral::advertise_connectable(sd, adv, &config).await);
 
         info!("advertising done!");

--- a/examples/src/bin/ble_bas_peripheral_notify.rs
+++ b/examples/src/bin/ble_bas_peripheral_notify.rs
@@ -35,7 +35,7 @@ use embassy_time::{Duration, Timer};
 use futures::future::{select, Either};
 use futures::pin_mut;
 use nrf_softdevice::ble::{gatt_server, peripheral, Connection};
-use nrf_softdevice::{generate_adv_data, generate_scan_data, raw, Softdevice};
+use nrf_softdevice::{generate_adv_data, raw, Softdevice};
 
 bind_interrupts!(struct Irqs {
     SAADC => saadc::InterruptHandler;
@@ -47,7 +47,7 @@ const ADV_DATA: &[u8] = generate_adv_data! {
     short_name: "HelloRust"
 };
 
-const SCAN_DATA: &[u8] = generate_scan_data! {
+const SCAN_DATA: &[u8] = generate_adv_data! {
     services: Complete16(HealthThermometer)
 };
 

--- a/examples/src/bin/ble_bond_peripheral.rs
+++ b/examples/src/bin/ble_bond_peripheral.rs
@@ -17,7 +17,7 @@ use nrf_softdevice::ble::security::{IoCapabilities, SecurityHandler};
 use nrf_softdevice::ble::{
     gatt_server, peripheral, Connection, EncryptionInfo, IdentityKey, MasterId, SecurityMode, Uuid,
 };
-use nrf_softdevice::{generate_adv_data, generate_scan_data, raw, Softdevice};
+use nrf_softdevice::{generate_adv_data, raw, Softdevice};
 use static_cell::StaticCell;
 
 const BATTERY_SERVICE: Uuid = Uuid::new_16(0x180f);
@@ -29,7 +29,7 @@ const ADV_DATA: &[u8] = generate_adv_data! {
     short_name: "HelloRust"
 };
 
-const SCAN_DATA: &[u8] = generate_scan_data! {
+const SCAN_DATA: &[u8] = generate_adv_data! {
     services: Complete16(HealthThermometer)
 };
 

--- a/examples/src/bin/ble_dis_bas_peripheral_builder.rs
+++ b/examples/src/bin/ble_dis_bas_peripheral_builder.rs
@@ -13,7 +13,7 @@ use nrf_softdevice::ble::gatt_server::builder::ServiceBuilder;
 use nrf_softdevice::ble::gatt_server::characteristic::{Attribute, Metadata, Properties};
 use nrf_softdevice::ble::gatt_server::{CharacteristicHandles, RegisterError, WriteOp};
 use nrf_softdevice::ble::{gatt_server, peripheral, Connection, Uuid};
-use nrf_softdevice::{generate_adv_data, generate_scan_data, raw, Softdevice};
+use nrf_softdevice::{generate_adv_data, raw, Softdevice};
 
 const DEVICE_INFORMATION: Uuid = Uuid::new_16(0x180a);
 const BATTERY_SERVICE: Uuid = Uuid::new_16(0x180f);
@@ -33,7 +33,7 @@ const ADV_DATA: &[u8] = generate_adv_data! {
     short_name: "HelloRust"
 };
 
-const SCAN_DATA: &[u8] = generate_scan_data! {
+const SCAN_DATA: &[u8] = generate_adv_data! {
     services: Complete16(HealthThermometer)
 };
 

--- a/examples/src/bin/ble_l2cap_peripheral.rs
+++ b/examples/src/bin/ble_l2cap_peripheral.rs
@@ -11,7 +11,7 @@ use core::ptr::NonNull;
 use defmt::*;
 use embassy_executor::Spawner;
 use nrf_softdevice::ble::{l2cap, peripheral};
-use nrf_softdevice::{ble, generate_adv_data, generate_scan_data, raw, RawError, Softdevice};
+use nrf_softdevice::{ble, generate_adv_data, raw, RawError, Softdevice};
 
 const PSM: u16 = 0x2349;
 
@@ -21,7 +21,7 @@ const ADV_DATA: &[u8] = generate_adv_data! {
     short_name: "HelloRst"
 };
 
-const SCAN_DATA: &[u8] = generate_scan_data! {
+const SCAN_DATA: &[u8] = generate_adv_data! {
     full_name: "Hello, Rust!"
 };
 

--- a/examples/src/bin/ble_peripheral_onoff.rs
+++ b/examples/src/bin/ble_peripheral_onoff.rs
@@ -13,7 +13,7 @@ use embassy_nrf::gpio::{Input, Pin as _, Pull};
 use embassy_nrf::interrupt::Priority;
 use futures::pin_mut;
 use nrf_softdevice::ble::{gatt_server, peripheral};
-use nrf_softdevice::{generate_adv_data, generate_scan_data, raw, Softdevice};
+use nrf_softdevice::{generate_adv_data, raw, Softdevice};
 
 const ADV_DATA: &[u8] = generate_adv_data! {
     flags: (GeneralDiscovery),
@@ -21,7 +21,7 @@ const ADV_DATA: &[u8] = generate_adv_data! {
     short_name: "HelloRust"
 };
 
-const SCAN_DATA: &[u8] = generate_scan_data! {
+const SCAN_DATA: &[u8] = generate_adv_data! {
     services: Complete16(HealthThermometer)
 };
 

--- a/nrf-softdevice-macro/Cargo.toml
+++ b/nrf-softdevice-macro/Cargo.toml
@@ -12,6 +12,8 @@ darling = "0.13.4"
 proc-macro2 = "1.0.18"
 Inflector = "0.11.4"
 uuid = "1.2.2"
+strum = "0.25.0"
+strum_macros = "0.25.2"
 
 [lib]
 proc-macro = true

--- a/nrf-softdevice-macro/src/lib.rs
+++ b/nrf-softdevice-macro/src/lib.rs
@@ -1083,22 +1083,22 @@ fn generate_data(input: TokenStream) -> (u8, TokenStream) {
 
 #[proc_macro]
 pub fn generate_adv_data(input: TokenStream) -> TokenStream {
-    let (len, tokens) = generate_data(input);
+    let (_, tokens) = generate_data(input);
 
-    if len > 31 {
-        panic!("Advertisement data may not exceed 31 bytes. Try using incomplete lists, or shortened names. You can put more info in the scan data.")
-    }
-
-    tokens
-}
-
-#[proc_macro]
-pub fn generate_scan_data(input: TokenStream) -> TokenStream {
-    let (len, tokens) = generate_data(input);
-
-    if len > 31 {
-        panic!("Scan data may not exceed 31 bytes. Try using incomplete lists, or shortened names.")
-    }
+    // if len > 31 {
+    //     panic!("Advertisement data may not exceed 31 bytes. Try using incomplete lists, or shortened names. You can put more info in the scan data.")
+    // }
 
     tokens
 }
+
+// #[proc_macro]
+// pub fn generate_scan_data(input: TokenStream) -> TokenStream {
+//     let (len, tokens) = generate_data(input);
+
+//     // if len > 31 {
+//     //     panic!("Scan data may not exceed 31 bytes. Try using incomplete lists, or shortened names.")
+//     // }
+
+//     tokens
+// }

--- a/nrf-softdevice-macro/src/lib.rs
+++ b/nrf-softdevice-macro/src/lib.rs
@@ -999,15 +999,16 @@ fn render_services(services: Services) -> (u8, TokenStream2) {
                         half_word_to_reversed_bytes(service.clone() as u16)
                     }
                     Service::Custom(string) => {
-                        length += 16;
-
+                        
                         if let Ok(uuid) = Uuid::from_string(string) {
                             match uuid {
                                 Uuid::Uuid128(bytes) => {
+                                    length += 16;
                                     quote! { #(#bytes),* }
                                 }
-                                _ => {
-                                    panic!("Invalid UUID. Custom UUIDs must be 16 bytes.");
+                                Uuid::Uuid16(int) => {
+                                    length += 2;
+                                    half_word_to_reversed_bytes(int)
                                 }
                             }
                         } else {

--- a/nrf-softdevice-macro/src/lib.rs
+++ b/nrf-softdevice-macro/src/lib.rs
@@ -887,7 +887,6 @@ impl Parse for Service {
 }
 
 #[derive(Debug)]
-#[repr(u8)]
 enum Services {
     Incomplete(u8, Vec<Service>),
     Complete(u8, Vec<Service>),

--- a/nrf-softdevice-macro/src/lib.rs
+++ b/nrf-softdevice-macro/src/lib.rs
@@ -798,7 +798,7 @@ enum BasicService {
     Glucose,
     HealthThermometer,
     DeviceInformation,
-    HeartRate,
+    HeartRate = 0x180d,
     PhoneAlertStatus,
     Battery,
     BloodPressure,
@@ -808,7 +808,7 @@ enum BasicService {
     RunnnigSpeedAndCadence,
     AutomationIO,
     CyclingSpeedAndCadence,
-    CyclingPower,
+    CyclingPower = 0x1818,
     LocationAndNavigation,
     EnvironmentalSensing,
     BodyComposition,
@@ -826,14 +826,14 @@ enum BasicService {
     MeshProvisioning,
     MeshProxy,
     ReconnectionConfiguration,
-    InsulinDelivery,
+    InsulinDelivery = 0x183a,
     BinarySensor,
     EmergencyConfiguration,
     AuthorizationControl,
     PhysicalActivityMonitor,
     ElapsedTime,
     GenericHealthSensor,
-    AudioInputControl,
+    AudioInputControl = 0x1843,
     VolumeControl,
     VolumeOffsetControl,
     CoordinatedSetIdentification,
@@ -875,8 +875,8 @@ impl Parse for Service {
                 let uuid: LitStr = content.parse()?;
                 Ok(Self::Custom(uuid.value()))
             }
-            _ => {
-                if let Ok(service) = BasicService::from_str("GenericAccess") {
+            other => {
+                if let Ok(service) = BasicService::from_str(other) {
                     Ok(Service::Basic16(service))
                 } else {
                     Err(input.error("Expected service identifier."))

--- a/nrf-softdevice-macro/src/lib.rs
+++ b/nrf-softdevice-macro/src/lib.rs
@@ -999,7 +999,6 @@ fn render_services(services: Services) -> (u8, TokenStream2) {
                         half_word_to_reversed_bytes(service.clone() as u16)
                     }
                     Service::Custom(string) => {
-                        
                         if let Ok(uuid) = Uuid::from_string(string) {
                             match uuid {
                                 Uuid::Uuid128(bytes) => {

--- a/nrf-softdevice/Cargo.toml
+++ b/nrf-softdevice/Cargo.toml
@@ -76,6 +76,9 @@ nrf-softdevice-s140 = { version = "0.1.1", path = "../nrf-softdevice-s140", opti
 
 nrf-softdevice-macro = { version = "0.1.0", path = "../nrf-softdevice-macro" }
 
+[dev-dependencies]
+uuid = { version = "1.6.1", default-features = false }
+
 [package.metadata.docs.rs]
 targets = ["thumbv7em-none-eabi"]
 features = ["nrf52840", "s140", "ble-central", "ble-peripheral", "ble-l2cap", "ble-gatt-server", "ble-gatt-client", "ble-rssi", "ble-sec"]

--- a/nrf-softdevice/src/ble/advertisement_builder.rs
+++ b/nrf-softdevice/src/ble/advertisement_builder.rs
@@ -1,0 +1,253 @@
+const ADV_LEN: usize = 31;
+
+#[allow(non_camel_case_types)]
+#[repr(u8)]
+pub enum ADType {
+    Flags = 0x01,
+    Incomplete16ServiceList,
+    Complete16ServiceList,
+    Incomplete32ServiceList,
+    Complete32ServiceList,
+    Incomplete128ServiceList,
+    Complete128ServiceList,
+    ShortName,
+    FullName,
+    TXPowerLevel,
+    PeripheralConnectionIntervalRange = 0x12,
+    ServiceSolicitation16 = 0x14,
+    ServiceSolicitation128,
+    ServiceSolicitation32 = 0x1f,
+    ServiceData16 = 0x16,
+    ServiceData32 = 0x20,
+    ServiceData128,
+    Appearance = 0x19,
+    PublicTargetAddress = 0x17,
+    RandomTargetAddress,
+    AdvertisingInterval = 0x1a,
+    URI = 0x24,
+    LE_SupportedFeatures = 0x27,
+    ManufacturerSpecificData = 0xff,
+}
+
+#[allow(non_camel_case_types)]
+#[derive(Clone, Copy)]
+#[repr(u8)]
+pub enum Flag {
+    LimitedDiscovery = 0b1,
+    GeneralDiscovery = 0b10,
+    LE_Only = 0b100,
+
+    // i don't understand these but in case people want them
+    Bit3 = 0b1000,
+    Bit4 = 0b10000,
+    // the rest are "reserved for future use"
+}
+
+pub trait Service {
+    const SIZE: usize;
+
+    fn render(self, adv: &mut AdvertisementData);
+}
+
+pub trait ServiceList<S: Service, const N: usize> {
+    const AD: ADType;
+
+    fn list(self) -> [S; N];
+}
+
+#[derive(Clone)]
+#[repr(u16)]
+pub enum BasicService {
+    GenericAccess = 0x1800,
+    GenericAttribute,
+    ImmediateAlert,
+    LinkLoss,
+    TxPower,
+    CurrentTime,
+    ReferenceTimeUpdate,
+    NextDSTChange,
+    Glucose,
+    HealthThermometer,
+    DeviceInformation,
+    HeartRate = 0x180d,
+    PhoneAlertStatus,
+    Battery,
+    BloodPressure,
+    AlertNotification,
+    HumanInterfaceDevice,
+    ScanParameters,
+    RunnnigSpeedAndCadence,
+    AutomationIO,
+    CyclingSpeedAndCadence,
+    CyclingPower = 0x1818,
+    LocationAndNavigation,
+    EnvironmentalSensing,
+    BodyComposition,
+    UserData,
+    WeightScale,
+    BondManagement,
+    ContinousGlucoseMonitoring,
+    InternetProtocolSupport,
+    IndoorPositioning,
+    PulseOximeter,
+    HTTPProxy,
+    TransportDiscovery,
+    ObjectTransfer,
+    FitnessMachine,
+    MeshProvisioning,
+    MeshProxy,
+    ReconnectionConfiguration,
+    InsulinDelivery = 0x183a,
+    BinarySensor,
+    EmergencyConfiguration,
+    AuthorizationControl,
+    PhysicalActivityMonitor,
+    ElapsedTime,
+    GenericHealthSensor,
+    AudioInputControl = 0x1843,
+    VolumeControl,
+    VolumeOffsetControl,
+    CoordinatedSetIdentification,
+    DeviceTime,
+    MediaControl,
+    GenericMediaControl, // why??
+    ConstantToneExtension,
+    TelephoneBearer,
+    GenericTelephoneBearer,
+    MicrophoneControl,
+    AudioStreamControl,
+    BroadcastAudioScan,
+    PublishedAudioScan,
+    BasicAudioCapabilities,
+    BroadcastAudioAnnouncement,
+    CommonAudio,
+    HearingAccess,
+    TelephonyAndMediaAudio,
+    PublicBroadcastAnnouncement,
+    ElectronicShelfLabel,
+    GamingAudio,
+    MeshProxySolicitation,
+}
+
+impl Service for BasicService {
+    const SIZE: usize = 2;
+
+    fn render(self, adv: &mut AdvertisementData) {
+        let data = (self as u16).swap_bytes().to_be_bytes();
+        adv.write(&data);
+    }
+}
+
+pub struct CustomService(pub [u8; 16]);
+
+impl Service for CustomService {
+    const SIZE: usize = 16;
+
+    fn render(mut self, adv: &mut AdvertisementData) {
+        self.0.reverse();
+        adv.write(&self.0);
+    }
+}
+
+pub struct Incomplete16<const N: usize>(pub [BasicService; N]);
+pub struct Complete16<const N: usize>(pub [BasicService; N]);
+pub struct Incomplete128<const N: usize>(pub [CustomService; N]);
+pub struct Complete128<const N: usize>(pub [CustomService; N]);
+
+macro_rules! impl_service_list {
+    ($LIST:ident, $SERVICE:ident, $AD:ident) => {
+        impl<const N: usize> ServiceList<$SERVICE, N> for $LIST<N> {
+            const AD: ADType = ADType::$AD;
+
+            fn list(self) -> [$SERVICE; N] {
+                self.0
+            }
+        }
+    };
+}
+
+impl_service_list!(Incomplete16, BasicService, Incomplete16ServiceList);
+impl_service_list!(Complete16, BasicService, Complete16ServiceList);
+impl_service_list!(Incomplete128, CustomService, Incomplete128ServiceList);
+impl_service_list!(Complete128, CustomService, Complete128ServiceList);
+
+pub trait Name {
+    const AD: ADType;
+
+    fn inner(&self) -> &str;
+}
+
+pub struct ShortName<'a>(pub &'a str);
+pub struct FullName<'a>(pub &'a str);
+
+macro_rules! impl_name {
+    ($NAME:ident, $AD:ident) => {
+        impl<'a> Name for $NAME<'a> {
+            const AD: ADType = ADType::$AD;
+
+            fn inner(&self) -> &str {
+                self.0
+            }
+        }
+    };
+}
+
+impl_name!(ShortName, ShortName);
+impl_name!(FullName, FullName);
+
+pub struct AdvertisementData {
+    buf: [u8; ADV_LEN],
+    ptr: usize,
+}
+
+impl AdvertisementData {
+    pub fn new() -> Self {
+        Self {
+            buf: [0; ADV_LEN],
+            ptr: 0,
+        }
+    }
+
+    fn write(&mut self, data: &[u8]) {
+        self.buf[self.ptr..self.ptr + data.len()].copy_from_slice(data);
+        self.ptr += data.len();
+    }
+
+    /// Write raw bytes to the advertisement data.
+    ///
+    /// *Note: The length is automatically computed and prepended.*
+    pub fn raw(mut self, ad: ADType, data: &[u8]) -> Self {
+        self.write(&[data.len() as u8 + 1, ad as u8]);
+        self.write(data);
+
+        self
+    }
+
+    /// View the resulting advertisement data in the form of a byte slice.
+    pub fn as_slice(&self) -> &[u8] {
+        &self.buf[..self.ptr]
+    }
+
+    /// Add flags to the advertisement data.
+    pub fn flags<const N: usize>(self, flags: [Flag; N]) -> Self {
+        let result = flags.iter().fold(0, |partial, &flag| partial + flag as u8);
+
+        self.raw(ADType::Flags, &[result])
+    }
+
+    /// Add a list of services to the advertisement data.
+    pub fn services<L: ServiceList<S, N>, S: Service, const N: usize>(mut self, services: L) -> Self {
+        self.write(&[(N * S::SIZE) as u8 + 1, L::AD as u8]);
+
+        for service in services.list() {
+            service.render(&mut self);
+        }
+
+        self
+    }
+
+    /// Add a name to the advertisement data.
+    pub fn name<N: Name>(self, name: N) -> Self {
+        self.raw(N::AD, name.inner().as_bytes())
+    }
+}

--- a/nrf-softdevice/src/ble/mod.rs
+++ b/nrf-softdevice/src/ble/mod.rs
@@ -14,12 +14,17 @@ pub use types::*;
 
 mod common;
 
+#[cfg(test)]
+mod tests;
+
 #[cfg(feature = "ble-sec")]
 pub mod security;
 
 #[cfg(feature = "ble-central")]
 pub mod central;
 
+#[cfg(feature = "ble-peripheral")]
+pub mod advertisement_builder;
 #[cfg(feature = "ble-peripheral")]
 pub mod peripheral;
 

--- a/nrf-softdevice/src/ble/tests.rs
+++ b/nrf-softdevice/src/ble/tests.rs
@@ -1,0 +1,59 @@
+use uuid::uuid;
+
+use super::advertisement_builder::*;
+
+#[test]
+fn basic() {
+    let adv_data = AdvertisementData::new()
+        .flags([Flag::GeneralDiscovery, Flag::LE_Only])
+        .services(Complete16([BasicService::HealthThermometer]))
+        .name(FullName("Full Name"));
+
+    #[rustfmt::skip]
+    assert_eq!(
+        adv_data.as_slice(),
+        &[
+            0x02, 0x01, 0x06,
+            0x03, 0x03, 0x09, 0x18,
+            0x0a, 0x09, b'F', b'u', b'l', b'l', b' ', b'N', b'a', b'm', b'e'
+        ]
+    );
+}
+
+#[test]
+fn custom_service() {
+    let test_service = CustomService(uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8").as_bytes().clone());
+
+    let adv_data = AdvertisementData::new()
+        .flags([Flag::GeneralDiscovery, Flag::LE_Only])
+        .services(Complete128([test_service]))
+        .name(ShortName("ShrtNm"));
+
+    #[rustfmt::skip]
+    assert_eq!(
+        adv_data.as_slice(),
+        &[
+            0x02, 0x01, 0x06,
+            0x11, 0x07, 0xc8, 0xe0, 0x5f, 0x0e, 0x68, 0xbb, 0x47, 0x92, 0x6f, 0x42, 0xb1, 0x10, 0x44, 0x50, 0xe5, 0x67,
+            0x07, 0x08, b'S', b'h', b'r', b't', b'N', b'm'
+        ]
+    );
+}
+
+#[test]
+fn raw() {
+    let adv_data = AdvertisementData::new()
+        .flags([Flag::GeneralDiscovery, Flag::LE_Only])
+        .raw(ADType::URI, &[0xde, 0xad, 0xbe, 0xef])
+        .name(ShortName("ShrtNm"));
+
+    #[rustfmt::skip]
+    assert_eq!(
+        adv_data.as_slice(),
+        &[
+            0x02, 0x01, 0x06,
+            0x05, 0x24, 0xde, 0xad, 0xbe, 0xef,
+            0x07, 0x08, b'S', b'h', b'r', b't', b'N', b'm'
+        ]
+    );
+}


### PR DESCRIPTION
## Motivation

This is how adv/scan data is currently configured:
```rust
#[rustfmt::skip]
let adv_data = &[
    0x02, 0x01, raw::BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE as u8,
    0x03, 0x03, 0x09, 0x18,
    0x0a, 0x09, b'H', b'e', b'l', b'l', b'o', b'R', b'u', b's', b't',
];
#[rustfmt::skip]
let scan_data = &[
    0x03, 0x03, 0x09, 0x18,
];
```

You don't often get to deal with raw bytes in a top level interface!

## Proposal

```rust
let adv_data = generate_adv_data! {
    flags: (LE_Only, GeneralDiscovery),
    services: Complete16(HealthThermometer),
    short_name: "HelloRust"
};

// expands to: &[2u8, 1u8, 2u8, 3u8, 3u8, 9u8, 24u8, 10u8, 9u8, 72u8, 101u8, 108u8, 108u8, 111u8, 82u8, 117u8, 115u8, 116u8];

let scan_data = generate_adv_data! {
    services: Complete16(HealthThermometer)
};

// expands to: &[3u8, 3u8, 9u8, 24u8];
```

With this PR, these code snippets are equivalent at runtime, as the array is generated by the proc macro at compile time.

## Changes

### Cargo

There are two additional dependencies: `strum` and `strum-macros`.

### `nrf-softdevice-macro`

In `lib.rs` there is one new proc macro: `generate_adv_data`, along with the associated structures made for its implementation.

### `examples`

All applicable examples have been updated to use the new macro instead of the raw array.

## Features
- all flags
- all 16bit services
- arbitrary 128bit services
- short/full name
- linting capability (won't compile if the resulting array is invalid)
- helpful error reporting

## Future
 - This PR contains no structures that allow modification of the adv/scan data arrays at runtime, this will be a future PR.
 - other AD types
 - improve errors
 - 32bit services??
 
## Examples

### Multiple 16bit Services

```rust
const ADV_DATA: &[u8] = generate_adv_data! {
    flags: (LE_Only, GeneralDiscovery),
    services: Complete16(HealthThermometer, GamingAudio),
    short_name: "HelloRust"
};
```

### Arbitrary 128bit Service

```rust
const ADV_DATA: &[u8] = generate_adv_data! {
    flags: (LE_Only, GeneralDiscovery),
    services: Complete128(Custom("e2b095d1-1b08-4e64-a942-842a7fa806bf")),
    short_name: "HelloRst" // max length with legacy (31 bytes)
};

const SCAN_DATA: &[u8] = generate_adv_data! {
    full_name: "Hello, Rust!" // but we can make up for it here
};
```

## Notes

I tried my best to decouple the structures as best as I could, there is a *little* bit of coupling left but I'd say it's a fine start