### PR TITLE
GATT Client support for receiving notifications

### DIFF
--- a/examples/src/bin/ble_bas_central.rs
+++ b/examples/src/bin/ble_bas_central.rs
@@ -82,4 +82,17 @@ async fn main(spawner: Spawner) {
     // Read to check it's changed
     let val = unwrap!(client.battery_level_read().await);
     info!("read battery level: {}", val);
+
+    // Enable battery level notifications from the peripheral
+    gatt_client::write(&conn, client.battery_level_cccd_handle, &[0x01, 0x00])
+        .await
+        .unwrap();
+
+    // Receive notifications
+    gatt_client::run(&conn, &client, |event| match event {
+        BatteryServiceClientEvent::BatteryLevelNotification(val) => {
+            info!("battery level notification: {}", val);
+        }
+    })
+    .await;
 }

--- a/examples/src/bin/ble_bas_central.rs
+++ b/examples/src/bin/ble_bas_central.rs
@@ -84,9 +84,7 @@ async fn main(spawner: Spawner) {
     info!("read battery level: {}", val);
 
     // Enable battery level notifications from the peripheral
-    gatt_client::write(&conn, client.battery_level_cccd_handle, &[0x01, 0x00])
-        .await
-        .unwrap();
+    client.battery_level_cccd_write(true).await.unwrap();
 
     // Receive notifications
     gatt_client::run(&conn, &client, |event| match event {

--- a/nrf-softdevice-macro/src/lib.rs
+++ b/nrf-softdevice-macro/src/lib.rs
@@ -657,6 +657,14 @@ pub fn gatt_client(args: TokenStream, item: TokenStream) -> TokenStream {
                     }
                 }
             ));
+
+            if !indicate {
+                code_impl.extend(quote_spanned!(ch.span=>
+                    #fn_vis async fn #cccd_write_fn(&self, notifications: bool) -> Result<(), #ble::gatt_client::WriteError> {
+                        #ble::gatt_client::write(&self.conn, self.#cccd_handle, &[if notifications { 0x01 } else { 0x00 }, 0x00]).await
+                    }
+                ));
+            }
         }
     }
 

--- a/nrf-softdevice-macro/src/lib.rs
+++ b/nrf-softdevice-macro/src/lib.rs
@@ -517,7 +517,7 @@ pub fn gatt_client(args: TokenStream, item: TokenStream) -> TokenStream {
     let mut code_disc_char = TokenStream2::new();
     let mut code_disc_done = TokenStream2::new();
     let mut code_event_enum = TokenStream2::new();
-    let mut code_on_notify = TokenStream2::new();
+    let mut code_on_hvx = TokenStream2::new();
 
     let ble = quote!(::nrf_softdevice::ble);
 
@@ -648,7 +648,7 @@ pub fn gatt_client(args: TokenStream, item: TokenStream) -> TokenStream {
             code_event_enum.extend(quote_spanned!(ch.span=>
                 #case_notification(#ty),
             ));
-            code_on_notify.extend(quote_spanned!(ch.span=>
+            code_on_hvx.extend(quote_spanned!(ch.span=>
                 if handle == self.#value_handle {
                     if data.len() < #ty_as_val::MIN_SIZE {
                         return None;
@@ -674,10 +674,10 @@ pub fn gatt_client(args: TokenStream, item: TokenStream) -> TokenStream {
         impl #ble::gatt_client::Client for #struct_name {
             type Event = #event_enum_name;
 
-            fn on_notify(&self, _conn: &::nrf_softdevice::ble::Connection, handle: u16, data: &[u8]) -> Option<Self::Event> {
+            fn on_hvx(&self, _conn: &::nrf_softdevice::ble::Connection, type_: ::nrf_softdevice::ble::gatt_client::HvxType, handle: u16, data: &[u8]) -> Option<Self::Event> {
                 use #ble::gatt_client::Client;
 
-                #code_on_notify
+                #code_on_hvx
                 None
             }
 

--- a/nrf-softdevice-macro/src/lib.rs
+++ b/nrf-softdevice-macro/src/lib.rs
@@ -538,6 +538,7 @@ pub fn gatt_client(args: TokenStream, item: TokenStream) -> TokenStream {
         let write_fn = format_ident!("{}_write", ch.name);
         let write_wor_fn = format_ident!("{}_write_without_response", ch.name);
         let write_try_wor_fn = format_ident!("{}_try_write_without_response", ch.name);
+        let cccd_write_fn = format_ident!("{}_cccd_write", ch.name);
         let fn_vis = ch.vis.clone();
 
         let uuid = ch.args.uuid;
@@ -649,7 +650,7 @@ pub fn gatt_client(args: TokenStream, item: TokenStream) -> TokenStream {
                 #case_notification(#ty),
             ));
             code_on_hvx.extend(quote_spanned!(ch.span=>
-                if handle == self.#value_handle {
+                if handle == self.#value_handle && type_ == ::nrf_softdevice::ble::gatt_client::HvxType::Notification {
                     if data.len() < #ty_as_val::MIN_SIZE {
                         return None;
                     } else {
@@ -665,6 +666,38 @@ pub fn gatt_client(args: TokenStream, item: TokenStream) -> TokenStream {
                     }
                 ));
             }
+        }
+
+        if indicate {
+            let case_indication = format_ident!("{}Indication", name_pascal);
+            code_event_enum.extend(quote_spanned!(ch.span=>
+                #case_indication(#ty),
+            ));
+            code_on_hvx.extend(quote_spanned!(ch.span=>
+                if handle == self.#value_handle && type_ == ::nrf_softdevice::ble::gatt_client::HvxType::Indication {
+                    if data.len() < #ty_as_val::MIN_SIZE {
+                        return None;
+                    } else {
+                        return Some(#event_enum_name::#case_indication(#ty_as_val::from_gatt(data)));
+                    }
+                }
+            ));
+
+            if !notify {
+                code_impl.extend(quote_spanned!(ch.span=>
+                    #fn_vis async fn #cccd_write_fn(&self, indications: bool) -> Result<(), #ble::gatt_client::WriteError> {
+                        #ble::gatt_client::write(&self.conn, self.#cccd_handle, &[if indications { 0x02 } else { 0x00 }, 0x00]).await
+                    }
+                ));
+            }
+        }
+
+        if indicate && notify {
+            code_impl.extend(quote_spanned!(ch.span=>
+                #fn_vis async fn #cccd_write_fn(&self, indications: bool, notifications: bool) -> Result<(), #ble::gatt_client::WriteError> {
+                    #ble::gatt_client::write(&self.conn, self.#cccd_handle, &[if indications { 0x02 } else { 0x00 } | if notifications { 0x01 } else { 0x00 }, 0x00]).await
+                }
+            ));
         }
     }
 

--- a/nrf-softdevice/src/ble/gatt_client.rs
+++ b/nrf-softdevice/src/ble/gatt_client.rs
@@ -23,6 +23,10 @@ pub struct Descriptor {
 
 /// Trait for implementing GATT clients.
 pub trait Client {
+    type Event;
+
+    fn on_notify(&self, conn: &Connection, handle: u16, data: &[u8]) -> Option<Self::Event>;
+
     /// Get the UUID of the GATT service. This is used by [`discover`] to search for the
     /// service in the GATT server.
     fn uuid() -> Uuid;
@@ -578,4 +582,48 @@ const PORTAL_NEW: Portal<*const raw::ble_evt_t> = Portal::new();
 static PORTALS: [Portal<*const raw::ble_evt_t>; CONNS_MAX] = [PORTAL_NEW; CONNS_MAX];
 pub(crate) fn portal(conn_handle: u16) -> &'static Portal<*const raw::ble_evt_t> {
     &PORTALS[conn_handle as usize]
+}
+
+pub async fn run<'a, F, C>(conn: &Connection, client: &C, mut f: F) -> DisconnectedError
+where
+    F: FnMut(C::Event),
+    C: Client,
+{
+    let handle = match conn.with_state(|state| state.check_connected()) {
+        Ok(handle) => handle,
+        Err(e) => return e,
+    };
+
+    portal(handle)
+        .wait_many(|ble_evt| unsafe {
+            let ble_evt = &*ble_evt;
+            if u32::from(ble_evt.header.evt_id) == raw::BLE_GAP_EVTS_BLE_GAP_EVT_DISCONNECTED {
+                return Some(DisconnectedError);
+            }
+
+            // We have a GATTC event
+            let gattc_evt = get_union_field(ble_evt, &ble_evt.evt.gattc_evt);
+            let conn = unwrap!(Connection::from_handle(gattc_evt.conn_handle));
+            let evt = match ble_evt.header.evt_id as u32 {
+                raw::BLE_GATTC_EVTS_BLE_GATTC_EVT_HVX => {
+                    let params = get_union_field(ble_evt, &gattc_evt.params.hvx);
+                    let v = get_flexarray(ble_evt, &params.data, params.len as usize);
+                    trace!(
+                        "GATT_HVX write handle={:?} type={:?} data={:?}",
+                        params.handle,
+                        params.type_,
+                        v
+                    );
+                    client.on_notify(&conn, params.handle, v)
+                }
+                _ => None,
+            };
+
+            if let Some(evt) = evt {
+                f(evt);
+            }
+
+            None
+        })
+        .await
 }


### PR DESCRIPTION
Closes #102.

Largely based off of the initial instructions by @sureshjoshi here: https://github.com/embassy-rs/nrf-softdevice/issues/102#issuecomment-1620341184

Wrote it in a similar fashion to how the `BLE_GATTS_EVTS_BLE_GATTS_EVT_WRITE` event is handled in the GATT server, and also updated the `gatt_client` macro to handle notifications.

~~Note: no extra method was added to do a CCCD write, so enabling notifications requires calling `gatt_client::write`.~~