### PR TITLE
L2CAP channel could get released while waiting

### DIFF
--- a/nrf-softdevice/src/ble/l2cap.rs
+++ b/nrf-softdevice/src/ble/l2cap.rs
@@ -381,6 +381,7 @@ impl<P: Packet> Channel<P> {
                         .wait_once(|ble_evt| unsafe {
                             match (*ble_evt).header.evt_id as u32 {
                                 raw::BLE_L2CAP_EVTS_BLE_L2CAP_EVT_CH_TX => (),
+                                raw::BLE_L2CAP_EVTS_BLE_L2CAP_EVT_CH_RELEASED => (),
                                 _ => unreachable!("Invalid event"),
                             }
                         })


### PR DESCRIPTION
I run into the `unreachable!` statement when I unplug the device on the other side.

Maybe this should error out directly, but this was the easiest way to fix the problem.
On the next call to `try_tx` after `continue` the connection is checked and returns `DisconnectedError`.