### PR TITLE
Add Serde Support

### DIFF
--- a/ci-stable.sh
+++ b/ci-stable.sh
@@ -16,7 +16,7 @@ cd nrf-softdevice
 cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
 cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,defmt
 cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,log
-
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,serde
 
 # build softdevice+chip combinations (with all supported features enabled)
 # This htis each softdevice and each chip at least once.

--- a/nrf-softdevice-macro/src/security_mode.rs
+++ b/nrf-softdevice-macro/src/security_mode.rs
@@ -4,6 +4,7 @@ use quote::{quote, ToTokens};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum SecurityMode {
     NoAccess,
     Open,

--- a/nrf-softdevice/Cargo.toml
+++ b/nrf-softdevice/Cargo.toml
@@ -46,6 +46,9 @@ evt-max-size-512 = []
 
 [dependencies]
 defmt = { version = "0.3", optional = true }
+serde = { version = "1.0", optional = true, default-features = false, features = [
+    "derive",
+] }
 log = { version = "0.4.11", optional = true }
 critical-section = { version = "1.0", optional = true }
 
@@ -60,13 +63,13 @@ futures = { version = "0.3.17", default-features = false }
 embedded-storage = "0.3.0"
 embedded-storage-async = { version = "0.4.0", optional = true }
 
-nrf52805-pac  = { version = "0.12.0", features = ["rt"], optional = true }
-nrf52810-pac  = { version = "0.12.0", features = ["rt"], optional = true }
-nrf52811-pac  = { version = "0.12.0", features = ["rt"], optional = true }
-nrf52820-pac  = { version = "0.12.0", features = ["rt"], optional = true }
-nrf52832-pac  = { version = "0.12.0", features = ["rt"], optional = true }
-nrf52833-pac  = { version = "0.12.0", features = ["rt"], optional = true }
-nrf52840-pac  = { version = "0.12.0", features = ["rt"], optional = true }
+nrf52805-pac = { version = "0.12.0", features = ["rt"], optional = true }
+nrf52810-pac = { version = "0.12.0", features = ["rt"], optional = true }
+nrf52811-pac = { version = "0.12.0", features = ["rt"], optional = true }
+nrf52820-pac = { version = "0.12.0", features = ["rt"], optional = true }
+nrf52832-pac = { version = "0.12.0", features = ["rt"], optional = true }
+nrf52833-pac = { version = "0.12.0", features = ["rt"], optional = true }
+nrf52840-pac = { version = "0.12.0", features = ["rt"], optional = true }
 
 nrf-softdevice-s112 = { version = "0.1.1", path = "../nrf-softdevice-s112", optional = true }
 nrf-softdevice-s113 = { version = "0.1.1", path = "../nrf-softdevice-s113", optional = true }
@@ -78,16 +81,70 @@ nrf-softdevice-macro = { version = "0.1.0", path = "../nrf-softdevice-macro" }
 
 [package.metadata.docs.rs]
 targets = ["thumbv7em-none-eabi"]
-features = ["nrf52840", "s140", "ble-central", "ble-peripheral", "ble-l2cap", "ble-gatt-server", "ble-gatt-client", "ble-rssi", "ble-sec"]
+features = [
+    "nrf52840",
+    "s140",
+    "ble-central",
+    "ble-peripheral",
+    "ble-l2cap",
+    "ble-gatt-server",
+    "ble-gatt-client",
+    "ble-rssi",
+    "ble-sec",
+]
 
 [package.metadata.embassy_docs]
 src_base = "https://github.com/embassy-rs/nrf-softdevice/blob/nrf-softdevice-mbr-v$VERSION/nrf-softdevice-mbr/src/"
 src_base_git = "https://github.com/embassy-rs/nrf-softdevice/blob/$COMMIT/nrf-softdevice-mbr/src/"
 target = "thumbv7em-none-eabi"
 flavors = [
-    { name = "s112", features = ["nrf52832", "s112", "ble-peripheral", "ble-gatt-server", "ble-gatt-client", "ble-rssi", "ble-sec"] },
-    { name = "s113", features = ["nrf52840", "s113", "ble-peripheral", "ble-l2cap", "ble-gatt-server", "ble-gatt-client", "ble-rssi", "ble-sec"] },
-    { name = "s122", features = ["nrf52833", "s122", "ble-central", "ble-gatt-server", "ble-gatt-client", "ble-rssi"] },
-    { name = "s132", features = ["nrf52832", "s132", "ble-central", "ble-peripheral", "ble-l2cap", "ble-gatt-server", "ble-gatt-client", "ble-rssi", "ble-sec"] },
-    { name = "s140", features = ["nrf52840", "s140", "ble-central", "ble-peripheral", "ble-l2cap", "ble-gatt-server", "ble-gatt-client", "ble-rssi", "ble-sec"] },
+    { name = "s112", features = [
+        "nrf52832",
+        "s112",
+        "ble-peripheral",
+        "ble-gatt-server",
+        "ble-gatt-client",
+        "ble-rssi",
+        "ble-sec",
+    ] },
+    { name = "s113", features = [
+        "nrf52840",
+        "s113",
+        "ble-peripheral",
+        "ble-l2cap",
+        "ble-gatt-server",
+        "ble-gatt-client",
+        "ble-rssi",
+        "ble-sec",
+    ] },
+    { name = "s122", features = [
+        "nrf52833",
+        "s122",
+        "ble-central",
+        "ble-gatt-server",
+        "ble-gatt-client",
+        "ble-rssi",
+    ] },
+    { name = "s132", features = [
+        "nrf52832",
+        "s132",
+        "ble-central",
+        "ble-peripheral",
+        "ble-l2cap",
+        "ble-gatt-server",
+        "ble-gatt-client",
+        "ble-rssi",
+        "ble-sec",
+    ] },
+    { name = "s140", features = [
+        "nrf52840",
+        "s140",
+        "ble-central",
+        "ble-peripheral",
+        "ble-l2cap",
+        "ble-gatt-server",
+        "ble-gatt-client",
+        "ble-rssi",
+        "ble-sec",
+    ] },
 ]

--- a/nrf-softdevice/src/ble/central.rs
+++ b/nrf-softdevice/src/ble/central.rs
@@ -12,6 +12,7 @@ use crate::{raw, RawError, Softdevice};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum ConnectError {
     Timeout,
     NoAddresses,
@@ -127,6 +128,7 @@ impl<'a> Default for ConnectConfig<'a> {
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum ScanError {
     Timeout,
     Raw(RawError),

--- a/nrf-softdevice/src/ble/connection.rs
+++ b/nrf-softdevice/src/ble/connection.rs
@@ -14,14 +14,17 @@ const BLE_GAP_DATA_LENGTH_DEFAULT: u8 = 27; //  The stack's default data length.
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub(crate) struct OutOfConnsError;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct DisconnectedError;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum SetConnParamsError {
     Disconnected,
     Raw(RawError),
@@ -41,6 +44,7 @@ impl From<RawError> for SetConnParamsError {
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg(feature = "ble-peripheral")]
 pub enum IgnoreSlaveLatencyError {
     Disconnected,

--- a/nrf-softdevice/src/ble/gatt_client.rs
+++ b/nrf-softdevice/src/ble/gatt_client.rs
@@ -24,6 +24,7 @@ pub struct Descriptor {
 #[repr(u8)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[non_exhaustive]
 pub enum HvxType {
     Invalid = 0,
@@ -77,6 +78,7 @@ pub trait Client {
 /// Error type for [`discover`]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum DiscoverError {
     /// Connection is disconnected.
     Disconnected,
@@ -314,6 +316,7 @@ pub async fn discover<T: Client>(conn: &Connection) -> Result<T, DiscoverError> 
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum ReadError {
     Disconnected,
     Truncated,
@@ -375,6 +378,7 @@ pub async fn read(conn: &Connection, handle: u16, buf: &mut [u8]) -> Result<usiz
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum WriteError {
     Disconnected,
     Timeout,
@@ -474,6 +478,7 @@ pub async fn write_without_response(conn: &Connection, handle: u16, buf: &[u8]) 
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum TryWriteError {
     Disconnected,
     BufferFull,
@@ -532,6 +537,7 @@ pub(crate) unsafe fn on_evt(ble_evt: *const raw::ble_evt_t) {
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum MtuExchangeError {
     /// Connection is disconnected.
     Disconnected,

--- a/nrf-softdevice/src/ble/gatt_server.rs
+++ b/nrf-softdevice/src/ble/gatt_server.rs
@@ -32,6 +32,7 @@ pub struct CharacteristicHandles {
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct ServiceHandle(u16);
 
 impl ServiceHandle {
@@ -42,6 +43,7 @@ impl ServiceHandle {
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct IncludedServiceHandle(u16);
 
 impl IncludedServiceHandle {
@@ -52,6 +54,7 @@ impl IncludedServiceHandle {
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct DescriptorHandle(u16);
 
 impl DescriptorHandle {
@@ -63,6 +66,7 @@ impl DescriptorHandle {
 #[repr(u8)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[non_exhaustive]
 pub enum WriteOp {
     Request = 1,
@@ -153,6 +157,7 @@ pub trait Service: Sized {
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum RegisterError {
     Raw(RawError),
 }
@@ -269,6 +274,7 @@ where
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum GetValueError {
     Truncated,
     Raw(RawError),
@@ -298,6 +304,7 @@ pub fn get_value(_sd: &Softdevice, handle: u16, buf: &mut [u8]) -> Result<usize,
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum SetValueError {
     Raw(RawError),
 }
@@ -322,6 +329,7 @@ pub fn set_value(_sd: &Softdevice, handle: u16, val: &[u8]) -> Result<(), SetVal
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum NotifyValueError {
     Disconnected,
     Raw(RawError),
@@ -359,6 +367,7 @@ pub fn notify_value(conn: &Connection, handle: u16, val: &[u8]) -> Result<(), No
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum IndicateValueError {
     Disconnected,
     Raw(RawError),
@@ -396,6 +405,7 @@ pub fn indicate_value(conn: &Connection, handle: u16, val: &[u8]) -> Result<(), 
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum GetSysAttrsError {
     DataSize(usize),
     Disconnected,
@@ -422,6 +432,7 @@ pub fn get_sys_attrs(conn: &Connection, buf: &mut [u8]) -> Result<usize, GetSysA
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum SetSysAttrsError {
     Disconnected,
     Raw(RawError),

--- a/nrf-softdevice/src/ble/gatt_server/characteristic.rs
+++ b/nrf-softdevice/src/ble/gatt_server/characteristic.rs
@@ -6,6 +6,7 @@ use crate::raw;
 
 #[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct AttributeMetadata {
     pub read: SecurityMode,
     pub write: SecurityMode,
@@ -58,6 +59,7 @@ impl AttributeMetadata {
 
 #[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Attribute<T: AsRef<[u8]>> {
     pub metadata: AttributeMetadata,
     pub value: T,
@@ -115,6 +117,7 @@ impl<T: AsRef<[u8]>> Attribute<T> {
 
 #[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct UserDescription {
     pub metadata: Option<AttributeMetadata>,
     pub value: &'static [u8],
@@ -123,6 +126,7 @@ pub struct UserDescription {
 
 #[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Properties {
     pub broadcast: bool,
     pub read: bool,
@@ -220,6 +224,8 @@ impl Properties {
 
 #[derive(Default, Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(bound(deserialize = "'de: 'static")))]
 pub struct Metadata {
     pub properties: Properties,
     pub user_description: Option<UserDescription>,

--- a/nrf-softdevice/src/ble/gatt_traits.rs
+++ b/nrf-softdevice/src/ble/gatt_traits.rs
@@ -4,6 +4,7 @@ use heapless::{String, Vec};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum FromGattError {
     InvalidLength,
     InvalidCharacter,

--- a/nrf-softdevice/src/ble/l2cap.rs
+++ b/nrf-softdevice/src/ble/l2cap.rs
@@ -73,6 +73,7 @@ pub(crate) unsafe fn on_evt(ble_evt: *const raw::ble_evt_t) {
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum TxError<P: Packet> {
     Disconnected,
     TxQueueFull(P),
@@ -92,6 +93,7 @@ impl<P: Packet> From<RawError> for TxError<P> {
 }
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum RxError {
     Disconnected,
     AllocateFailed,
@@ -112,6 +114,7 @@ impl From<RawError> for RxError {
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum SetupError {
     Disconnected,
     Refused,

--- a/nrf-softdevice/src/ble/peripheral.rs
+++ b/nrf-softdevice/src/ble/peripheral.rs
@@ -18,6 +18,7 @@ struct RawAdvertisement<'a> {
 /// Connectable advertisement types, which can accept connections from interested Central devices.
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum ConnectableAdvertisement<'a> {
     ScannableUndirected {
         adv_data: &'a [u8],
@@ -95,6 +96,7 @@ impl<'a> From<ConnectableAdvertisement<'a>> for RawAdvertisement<'a> {
 /// only used to broadcast information in the air.
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum NonconnectableAdvertisement<'a> {
     ScannableUndirected {
         adv_data: &'a [u8],
@@ -204,6 +206,7 @@ impl<'a> From<NonconnectableAdvertisement<'a>> for RawAdvertisement<'a> {
 /// Error for [`advertise_start`]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum AdvertiseError {
     Timeout,
     NoFreeConn,
@@ -399,6 +402,7 @@ where
 #[repr(u8)]
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum FilterPolicy {
     #[default]
     Any = raw::BLE_GAP_ADV_FP_ANY as u8,

--- a/nrf-softdevice/src/ble/security.rs
+++ b/nrf-softdevice/src/ble/security.rs
@@ -5,6 +5,7 @@ use crate::raw;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum IoCapabilities {
     None,
     DisplayYesNo,

--- a/nrf-softdevice/src/ble/types.rs
+++ b/nrf-softdevice/src/ble/types.rs
@@ -65,6 +65,7 @@ impl PartialEq for Uuid {
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum Role {
     #[cfg(feature = "ble-central")]
     Central,
@@ -86,6 +87,7 @@ impl Role {
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum SecurityMode {
     NoAccess,
     Open,
@@ -136,6 +138,7 @@ impl SecurityMode {
 #[repr(u8)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum AddressType {
     /// Public (identity) address
     Public = 0x00,
@@ -151,6 +154,7 @@ pub enum AddressType {
 
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct InvalidAddressType;
 
 impl TryFrom<u8> for AddressType {
@@ -176,6 +180,7 @@ impl TryFrom<u8> for AddressType {
 // Note: this type MUST be layout-compatible with raw::ble_gap_addr_t
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Address {
     // bit 0: is resolved private address
     // bits 7-1: type
@@ -236,6 +241,7 @@ impl defmt::Format for Address {
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Eq, PartialEq, Copy, Clone)]
 #[repr(i8)]
 pub enum TxPower {
@@ -261,6 +267,7 @@ pub enum TxPower {
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Eq, PartialEq, Copy, Clone)]
 #[repr(u8)]
 pub enum Phy {
@@ -274,6 +281,7 @@ pub enum Phy {
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Eq, PartialEq, Copy, Clone)]
 #[repr(u8)]
 pub enum PhySet {
@@ -300,6 +308,7 @@ pub enum PhySet {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct MasterId {
     /// Encrypted diversifier
     pub ediv: u16,
@@ -320,6 +329,7 @@ impl MasterId {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct EncryptionInfo {
     /// Long term key
     pub ltk: [u8; 16],
@@ -342,6 +352,7 @@ impl EncryptionInfo {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct IdentityResolutionKey {
     irk: [u8; 16],
 }
@@ -361,6 +372,7 @@ impl IdentityResolutionKey {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct IdentityKey {
     /// Identity resolution key
     pub irk: IdentityResolutionKey,

--- a/nrf-softdevice/src/events.rs
+++ b/nrf-softdevice/src/events.rs
@@ -16,6 +16,7 @@ static SWI2_BLE_EVT_WAKER: AtomicWaker = AtomicWaker::new();
 #[repr(u32)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, IntoPrimitive, TryFromPrimitive)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize,serde::Serialize))]
 pub enum SocEvent {
     Hfclkstarted = raw::NRF_SOC_EVTS_NRF_EVT_HFCLKSTARTED,
     PowerFailureWarning = raw::NRF_SOC_EVTS_NRF_EVT_POWER_FAILURE_WARNING,

--- a/nrf-softdevice/src/flash.rs
+++ b/nrf-softdevice/src/flash.rs
@@ -12,6 +12,7 @@ use crate::{raw, RawError, Softdevice};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[non_exhaustive]
 pub enum FlashError {
     Failed,

--- a/nrf-softdevice/src/random.rs
+++ b/nrf-softdevice/src/random.rs
@@ -2,6 +2,7 @@ use crate::{raw, RawError, Softdevice};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum RandomError {
     BufferTooBig,
     NotEnoughEntropy,

--- a/nrf-softdevice/src/raw_error.rs
+++ b/nrf-softdevice/src/raw_error.rs
@@ -6,6 +6,7 @@ use crate::raw;
 #[rustfmt::skip]
 #[repr(u32)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize,serde::Serialize))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, IntoPrimitive, FromPrimitive)]
 pub enum RawError {
     /// This is not really an error, but is added here anyway, just in case someone mistakenly converts NRF_SUCCESS into RawError.

--- a/nrf-softdevice/src/temperature.rs
+++ b/nrf-softdevice/src/temperature.rs
@@ -4,6 +4,7 @@ use crate::{raw, RawError, Softdevice};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum TempError {
     Raw(RawError),
 }


### PR DESCRIPTION
The title kind of says it. 

I had a use case where I would want to persist and transmit some structs used in `nrf-softdevice`, so they would need to be serialized to a wire format. 

Serde supports `no_std` so I did the thing and added the impls behind a flag. 