### PR TITLE
Typo in credit workaround feature name

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -60,7 +60,7 @@ cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf
 cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-server
 cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client
 cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,ble-l2cap-credit-wrokaround,ble-rssi
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,ble-l2cap-credit-workaround,ble-rssi
 
 cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral
 cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-peripheral,ble-gatt-server
@@ -79,4 +79,4 @@ cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf
 cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-server
 cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client
 cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
-cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,ble-l2cap-credit-wrokaround,ble-rssi
+cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,ble-l2cap-credit-workaround,ble-rssi

--- a/nrf-softdevice/Cargo.toml
+++ b/nrf-softdevice/Cargo.toml
@@ -37,7 +37,9 @@ usable-from-interrupts = []
 # Workaround l2cap credit bug. If set, infinite credits are issued
 # to the peer in batches. The `credits` config when establishing the channel is ignored.
 # https://devzone.nordicsemi.com/f/nordic-q-a/81894/s140-7-3-0-softdevice-assertion-failed-at-pc-0xa806-using-l2cap
-ble-l2cap-credit-wrokaround = []
+ble-l2cap-credit-workaround = []
+# Stay compatible with the old feature name for now.
+ble-l2cap-credit-wrokaround = ["ble-l2cap-credit-workaround"]
 
 evt-max-size-256 = []
 evt-max-size-512 = []

--- a/nrf-softdevice/Cargo.toml
+++ b/nrf-softdevice/Cargo.toml
@@ -38,8 +38,6 @@ usable-from-interrupts = []
 # to the peer in batches. The `credits` config when establishing the channel is ignored.
 # https://devzone.nordicsemi.com/f/nordic-q-a/81894/s140-7-3-0-softdevice-assertion-failed-at-pc-0xa806-using-l2cap
 ble-l2cap-credit-workaround = []
-# Stay compatible with the old feature name for now.
-ble-l2cap-credit-wrokaround = ["ble-l2cap-credit-workaround"]
 
 evt-max-size-256 = []
 evt-max-size-512 = []

--- a/nrf-softdevice/src/ble/l2cap.rs
+++ b/nrf-softdevice/src/ble/l2cap.rs
@@ -18,7 +18,7 @@ use crate::ble::*;
 use crate::util::{get_union_field, Portal};
 use crate::{raw, RawError, Softdevice};
 
-#[cfg(feature = "ble-l2cap-credit-wrokaround")]
+#[cfg(feature = "ble-l2cap-credit-workaround")]
 fn credit_hack_refill(conn: u16, cid: u16) {
     const CREDITS_MAX: u16 = 0xFFFF;
     const CREDITS_MIN: u16 = 1024;
@@ -243,7 +243,7 @@ impl<P: Packet> L2cap<P> {
 
                         // default is 1
                         let _ = config.credits;
-                        #[cfg(not(feature = "ble-l2cap-credit-wrokaround"))]
+                        #[cfg(not(feature = "ble-l2cap-credit-workaround"))]
                         if config.credits != 1 {
                             let ret =
                                 raw::sd_ble_l2cap_ch_flow_control(conn_handle, cid, config.credits, ptr::null_mut());
@@ -322,7 +322,7 @@ impl<P: Packet> L2cap<P> {
 
                             // default is 1
                             let _ = config.credits;
-                            #[cfg(not(feature = "ble-l2cap-credit-wrokaround"))]
+                            #[cfg(not(feature = "ble-l2cap-credit-workaround"))]
                             if config.credits != 1 {
                                 let ret = raw::sd_ble_l2cap_ch_flow_control(
                                     conn_handle,
@@ -473,7 +473,7 @@ impl<P: Packet> Channel<P> {
             return Err(err.into());
         }
 
-        #[cfg(feature = "ble-l2cap-credit-wrokaround")]
+        #[cfg(feature = "ble-l2cap-credit-workaround")]
         credit_hack_refill(conn_handle, self.cid);
 
         portal(conn_handle)


### PR DESCRIPTION
I left the old name as an alias so no code should break.