### PR TITLE
examples: Make examples also buildable for nrf52832

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ Flashing the softdevice is required. It is NOT part of the built binary. You onl
 
 To run an example, simply use `cargo run` from the `examples` folder:
 
-- `cd examples && cargo run --bin ble_bas_peripheral`
+- `cd examples && cargo run --bin ble_bas_peripheral --features nrf52840`
+
+Examples can also built for nrf52832 chip targeting S132 softdevice.
 
 ## Configuring a SoftDevice
 

--- a/ci.sh
+++ b/ci.sh
@@ -2,14 +2,17 @@
 
 set -euxo pipefail
 
-# build examples
-#==================
+# Build examples
+#===============
 
-(cd examples; cargo build --target thumbv7em-none-eabihf --bins)
+cd examples
+cargo build --target thumbv7em-none-eabihf --features nrf52832 --bins
+cargo build --target thumbv7em-none-eabihf --features nrf52840 --bins
+cd ..
 
 
-# build with log/defmt combinations
-#=====================================
+# Build with log/defmt combinations
+#==================================
 
 cd nrf-softdevice
 
@@ -18,9 +21,9 @@ cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf
 cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server,log
 
 
-# build softdevice+chip combinations (with all supported features enabled)
-# This htis each softdevice and each chip at least once.
-#================================================================================
+# Build softdevice+chip combinations (with all supported features enabled)
+# This hits each softdevice and each chip at least once.
+#=========================================================================
 
 cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s112,nrf52805,ble-sec,ble-peripheral,ble-gatt-client,ble-gatt-server
 cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s113,nrf52810,ble-sec,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
@@ -31,8 +34,8 @@ cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf
 cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-sec,ble-central,ble-peripheral,ble-l2cap,ble-gatt-client,ble-gatt-server
 
 
-# build all feature combinations
-#==================================
+# Build all feature combinations
+#===============================
 
 cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral
 cargo build --target thumbv7em-none-eabihf -p nrf-softdevice --features s140,nrf52840,ble-peripheral,ble-gatt-server

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -17,18 +17,30 @@ ble-gatt-server = ["nrf-softdevice/ble-gatt-server"]
 ble-gatt-client = ["nrf-softdevice/ble-gatt-client"]
 ble-sec = ["nrf-softdevice/ble-sec"]
 
+nrf52832 = [
+  "embassy-nrf/nrf52832",
+  "nrf-softdevice/nrf52832",
+  "nrf-softdevice/s132",
+  "dep:nrf-softdevice-s132"
+]
+nrf52840 = [
+  "embassy-nrf/nrf52840",
+  "nrf-softdevice/nrf52840",
+  "nrf-softdevice/s140",
+  "dep:nrf-softdevice-s140"
+]
+
 [dependencies]
 embassy-executor = { version = "0.3.3", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt", "integrated-timers"]}
 embassy-time = { version = "0.2.0", features = ["defmt", "defmt-timestamp-uptime"]}
 embassy-sync = { version = "0.5.0" }
-embassy-nrf = { version = "0.1.0", features = ["defmt", "nrf52840", "gpiote", "time-driver-rtc1" ]}
+embassy-nrf = { version = "0.1.0", features = ["defmt", "gpiote", "time-driver-rtc1" ]}
 cortex-m = "0.7.7"
 cortex-m-rt = "0.7.3"
 defmt = "0.3.5"
 defmt-rtt = "0.4.0"
 panic-probe = { version = "0.3.1", features= ["print-defmt"] }
-nrf-softdevice = { version = "0.1.0", path = "../nrf-softdevice", features = ["defmt", "nrf52840", "s140", "ble-peripheral", "ble-central", "critical-section-impl"] }
-nrf-softdevice-s140 = { version = "0.1.1", path = "../nrf-softdevice-s140" }
+nrf-softdevice = { version = "0.1.0", path = "../nrf-softdevice", features = ["defmt", "ble-peripheral", "ble-central", "critical-section-impl"] }
 embedded-storage = "0.3.1"
 embedded-storage-async = "0.4.1"
 futures = { version = "0.3.29", default-features = false }
@@ -36,6 +48,9 @@ fixed = "1.24.0"
 heapless = "0.8.0"
 atomic-pool = "1.0.1"
 static_cell = "2.0.0"
+
+nrf-softdevice-s132 = { version = "0.1.1", path = "../nrf-softdevice-s132", optional = true }
+nrf-softdevice-s140 = { version = "0.1.1", path = "../nrf-softdevice-s140", optional = true }
 
 [[bin]]
 name = "ble_bas_peripheral"

--- a/examples/build.rs
+++ b/examples/build.rs
@@ -13,13 +13,29 @@ use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 
+fn linker_data() -> &'static [u8] {
+    #[cfg(feature = "nrf52832")]
+    return include_bytes!("memory-nrf52832.x");
+    #[cfg(feature = "nrf52840")]
+    return include_bytes!("memory-nrf52840.x");
+
+    #[cfg(any(
+        feature = "nrf52805",
+        feature = "nrf52810",
+        feature = "nrf52811",
+        feature = "nrf52820",
+        feature = "nrf52833",
+    ))]
+    panic!("Unable to build examples for currently selected chip due to missing chip-specific linker configuration (memory.x)");
+}
+
 fn main() {
     // Put `memory.x` in our output directory and ensure it's
     // on the linker search path.
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
     File::create(out.join("memory.x"))
         .unwrap()
-        .write_all(include_bytes!("memory.x"))
+        .write_all(linker_data())
         .unwrap();
     println!("cargo:rustc-link-search={}", out.display());
 

--- a/examples/memory-nrf52832.x
+++ b/examples/memory-nrf52832.x
@@ -1,0 +1,7 @@
+MEMORY
+{
+  /* NOTE 1 K = 1 KiBi = 1024 bytes */
+  /* NRF52832 with Softdevice S132 7.x and 6.x */
+  FLASH : ORIGIN = 0x00026000, LENGTH = 512K - 152K
+  RAM : ORIGIN = 0x20000000 + 30K, LENGTH = 64K - 30K
+}

--- a/examples/memory-nrf52840.x
+++ b/examples/memory-nrf52840.x
@@ -1,7 +1,7 @@
 MEMORY
 {
   /* NOTE 1 K = 1 KiBi = 1024 bytes */
-  /* These values correspond to the NRF52840 with Softdevices S140 7.0.1 */
+  /* NRF52840 with Softdevice S140 7.0.1 */
   FLASH : ORIGIN = 0x00027000, LENGTH = 868K
   RAM : ORIGIN = 0x20020000, LENGTH = 128K
 }

--- a/nrf-softdevice/src/lib.rs
+++ b/nrf-softdevice/src/lib.rs
@@ -64,12 +64,12 @@ compile_error!("No chip feature activated. You must activate exactly one of the 
     all(feature = "nrf52832", feature = "nrf52840"),
     all(feature = "nrf52833", feature = "nrf52840"),
 ))]
-compile_error!("Multile chip features activated. You must activate exactly one of the following features: nrf52810, nrf52811, nrf52832, nrf52833, nrf52840");
+compile_error!("Multiple chip features activated. You must activate exactly one of the following features: nrf52810, nrf52811, nrf52832, nrf52833, nrf52840");
 
 // https://www.nordicsemi.com/Software-and-tools/Software/Bluetooth-Software
 //
-//      | Central  Peripheral  L2CAP-CoC | nrf52805  nrf52810  nrf52811  nrf52820  nrf52832  nrf52833, nrf52840
-// -----|--------------------------------|--------------------------------------------------------------------------
+//      | Central  Peripheral  L2CAP-CoC | nrf52805  nrf52810  nrf52811  nrf52820  nrf52832  nrf52833  nrf52840
+// -----|--------------------------------|----------------------------------------------------------------------
 // s112 |              X                 |    X         X         X         X         X
 // s113 |              X           X     |    X         X         X         X         X         X         X
 // s122 |    X                           |                                  X                   X


### PR DESCRIPTION
It's now possible to use `--features ...` to build/run examples for either nrf52832 or nrf52840 chip.
And examples are now built with following targets:
* nrf52832 and s132
* nrf52840 and s140