### PR TITLE
chore: bump version for release

### DIFF
--- a/nrf-softdevice-mbr/Cargo.toml
+++ b/nrf-softdevice-mbr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf-softdevice-mbr"
-version = "0.1.1"
+version = "0.2.0"
 description = "Low-level bindings for the MBR included in all Nordic nRF SoftDevices"
 authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 repository = "https://github.com/embassy-rs/nrf-softdevice"


### PR DESCRIPTION
I think it makes sense to release it as the current version on crates.io has the wrong github repository, and there have been some updates to the crate.

@Dirbaio You stand as sole owner on crates.io