### PR TITLE
examples: Align services in scan data with provided services

### DIFF
--- a/examples/src/bin/ble_dis_bas_peripheral_builder.rs
+++ b/examples/src/bin/ble_dis_bas_peripheral_builder.rs
@@ -231,12 +231,17 @@ async fn main(spawner: Spawner) {
     #[rustfmt::skip]
     let adv_data = &[
         0x02, 0x01, raw::BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE as u8,
-        0x03, 0x03, 0x09, 0x18,
+        0x03,
+            0x02, /* Incomplete List of 16-bit Service Class UUIDs */
+                0x0f, 0x18, /* Battery service */
         0x0a, 0x09, b'H', b'e', b'l', b'l', b'o', b'R', b'u', b's', b't',
     ];
     #[rustfmt::skip]
     let scan_data = &[
-        0x03, 0x03, 0x09, 0x18,
+        0x05,
+            0x03 /* Complete List of 16-bit Service Class UUIDs */,
+                0x0a, 0x18, /* Device Information service */
+                0x0f, 0x18, /* Battery service */
     ];
 
     loop {


### PR DESCRIPTION
The scan data of the example previously indicated being a thermometer (which the nRF chip clearly is, not even a bad one), but which does not match the services that it offers on GATT.

This change enables using the device with the WebBluetooth example at https://googlechrome.github.io/samples/web-bluetooth/battery-level-async-await.html (on Android and Linux), which previously only worked on Linux when pairing to the device manually through blueman (which caused more data from the device available to the host).

[edit: Another good example is <https://googlechrome.github.io/samples/web-bluetooth/device-information-characteristics-async-await.html>, which also works now]

[edit 2: insta-forcepushed another change after I noticed that the thermometer was still around in the adv_data; now adv_data announces one service and scan_data all.]