### PR TITLE
Refactor advertisement_builder with a fully const API

### DIFF
--- a/examples/src/bin/ble_advertise.rs
+++ b/examples/src/bin/ble_advertise.rs
@@ -9,7 +9,7 @@ use core::mem;
 use defmt::{info, *};
 use embassy_executor::Spawner;
 use nrf_softdevice::ble::advertisement_builder::{
-    BasicService, Flag, LegacyAdvertisementBuilder, LegacyAdvertisementPayload, ServiceList,
+    Flag, LegacyAdvertisementBuilder, LegacyAdvertisementPayload, ServiceList, ServiceUuid16,
 };
 use nrf_softdevice::ble::peripheral;
 use nrf_softdevice::{raw, Softdevice};
@@ -63,7 +63,7 @@ async fn main(spawner: Spawner) {
 
     static ADV_DATA: LegacyAdvertisementPayload = LegacyAdvertisementBuilder::new()
         .flags(&[Flag::GeneralDiscovery])
-        .services_16(ServiceList::Complete, &[BasicService::HealthThermometer]) // if there were a lot of these there may not be room for the full name
+        .services_16(ServiceList::Complete, &[ServiceUuid16::HEALTH_THERMOMETER]) // if there were a lot of these there may not be room for the full name
         .short_name("HelloRust")
         .build();
 

--- a/examples/src/bin/ble_advertise.rs
+++ b/examples/src/bin/ble_advertise.rs
@@ -62,9 +62,9 @@ async fn main(spawner: Spawner) {
     config.interval = 50;
 
     static ADV_DATA: LegacyAdvertisementPayload = LegacyAdvertisementBuilder::new()
-        .flags(&[Flag::GeneralDiscovery])
+        .flags(&[Flag::GeneralDiscovery, Flag::LE_Only])
         .services_16(ServiceList::Complete, &[ServiceUuid16::HEALTH_THERMOMETER]) // if there were a lot of these there may not be room for the full name
-        .short_name("HelloRust")
+        .short_name("Hello")
         .build();
 
     // but we can put it in the scan data

--- a/examples/src/bin/ble_bas_peripheral.rs
+++ b/examples/src/bin/ble_bas_peripheral.rs
@@ -78,13 +78,16 @@ async fn main(spawner: Spawner) {
     unwrap!(spawner.spawn(softdevice_task(sd)));
 
     static ADV_DATA: LegacyAdvertisementPayload = LegacyAdvertisementBuilder::new()
-        .flags(&[Flag::GeneralDiscovery])
-        .services_16(ServiceList::Complete, &[ServiceUuid16::HEALTH_THERMOMETER])
-        .short_name("HelloRust")
+        .flags(&[Flag::GeneralDiscovery, Flag::LE_Only])
+        .services_16(ServiceList::Complete, &[ServiceUuid16::BATTERY])
+        .full_name("HelloRust")
         .build();
 
     static SCAN_DATA: LegacyAdvertisementPayload = LegacyAdvertisementBuilder::new()
-        .services_16(ServiceList::Complete, &[ServiceUuid16::HEALTH_THERMOMETER])
+        .services_128(
+            ServiceList::Complete,
+            &[0x9e7312e0_2354_11eb_9f10_fbc30a62cf38_u128.to_le_bytes()],
+        )
         .build();
 
     loop {

--- a/examples/src/bin/ble_bas_peripheral.rs
+++ b/examples/src/bin/ble_bas_peripheral.rs
@@ -9,7 +9,7 @@ use core::mem;
 use defmt::{info, *};
 use embassy_executor::Spawner;
 use nrf_softdevice::ble::advertisement_builder::{
-    BasicService, Flag, LegacyAdvertisementBuilder, LegacyAdvertisementPayload, ServiceList,
+    Flag, LegacyAdvertisementBuilder, LegacyAdvertisementPayload, ServiceList, ServiceUuid16,
 };
 use nrf_softdevice::ble::{gatt_server, peripheral};
 use nrf_softdevice::{raw, Softdevice};
@@ -79,12 +79,12 @@ async fn main(spawner: Spawner) {
 
     static ADV_DATA: LegacyAdvertisementPayload = LegacyAdvertisementBuilder::new()
         .flags(&[Flag::GeneralDiscovery])
-        .services_16(ServiceList::Complete, &[BasicService::HealthThermometer])
+        .services_16(ServiceList::Complete, &[ServiceUuid16::HEALTH_THERMOMETER])
         .short_name("HelloRust")
         .build();
 
     static SCAN_DATA: LegacyAdvertisementPayload = LegacyAdvertisementBuilder::new()
-        .services_16(ServiceList::Complete, &[BasicService::HealthThermometer])
+        .services_16(ServiceList::Complete, &[ServiceUuid16::HEALTH_THERMOMETER])
         .build();
 
     loop {

--- a/examples/src/bin/ble_bas_peripheral_notify.rs
+++ b/examples/src/bin/ble_bas_peripheral_notify.rs
@@ -143,14 +143,12 @@ async fn main(spawner: Spawner) {
     unwrap!(spawner.spawn(softdevice_task(sd)));
 
     static ADV_DATA: LegacyAdvertisementPayload = LegacyAdvertisementBuilder::new()
-        .flags(&[Flag::GeneralDiscovery])
-        .services_16(ServiceList::Complete, &[ServiceUuid16::HEALTH_THERMOMETER])
-        .short_name("HelloRust")
+        .flags(&[Flag::GeneralDiscovery, Flag::LE_Only])
+        .services_16(ServiceList::Complete, &[ServiceUuid16::BATTERY])
+        .full_name("HelloRust")
         .build();
 
-    static SCAN_DATA: LegacyAdvertisementPayload = LegacyAdvertisementBuilder::new()
-        .services_16(ServiceList::Complete, &[ServiceUuid16::HEALTH_THERMOMETER])
-        .build();
+    static SCAN_DATA: [u8; 0] = [];
 
     loop {
         let config = peripheral::Config::default();

--- a/examples/src/bin/ble_bas_peripheral_notify.rs
+++ b/examples/src/bin/ble_bas_peripheral_notify.rs
@@ -33,10 +33,10 @@ use embassy_nrf::{bind_interrupts, interrupt, saadc};
 use embassy_time::{Duration, Timer};
 use futures::future::{select, Either};
 use futures::pin_mut;
-use nrf_softdevice::ble::{
-    advertisement_builder::{BasicService, Complete16, Flag, ShortName, StandardAdvertisementData},
-    gatt_server, peripheral, Connection,
+use nrf_softdevice::ble::advertisement_builder::{
+    BasicService, Flag, LegacyAdvertisementBuilder, LegacyAdvertisementPayload, ServiceList,
 };
+use nrf_softdevice::ble::{gatt_server, peripheral, Connection};
 use nrf_softdevice::{raw, Softdevice};
 
 bind_interrupts!(struct Irqs {
@@ -142,19 +142,22 @@ async fn main(spawner: Spawner) {
 
     unwrap!(spawner.spawn(softdevice_task(sd)));
 
-    let adv_data = StandardAdvertisementData::new()
-        .flags([Flag::GeneralDiscovery])
-        .services(Complete16([BasicService::HealthThermometer]))
-        .name(ShortName("HelloRust"));
+    static ADV_DATA: LegacyAdvertisementPayload = LegacyAdvertisementBuilder::new()
+        .flags(&[Flag::GeneralDiscovery])
+        .services_16(ServiceList::Complete, &[BasicService::HealthThermometer])
+        .short_name("HelloRust")
+        .build();
 
-    let scan_data = StandardAdvertisementData::new().services(Complete16([BasicService::HealthThermometer]));
+    static SCAN_DATA: LegacyAdvertisementPayload = LegacyAdvertisementBuilder::new()
+        .services_16(ServiceList::Complete, &[BasicService::HealthThermometer])
+        .build();
 
     loop {
         let config = peripheral::Config::default();
 
         let adv = peripheral::ConnectableAdvertisement::ScannableUndirected {
-            adv_data: unwrap!(adv_data.as_slice()),
-            scan_data: unwrap!(scan_data.as_slice()),
+            adv_data: &ADV_DATA,
+            scan_data: &SCAN_DATA,
         };
         let conn = unwrap!(peripheral::advertise_connectable(sd, adv, &config).await);
         info!("advertising done! I have a connection.");

--- a/examples/src/bin/ble_bas_peripheral_notify.rs
+++ b/examples/src/bin/ble_bas_peripheral_notify.rs
@@ -34,7 +34,7 @@ use embassy_time::{Duration, Timer};
 use futures::future::{select, Either};
 use futures::pin_mut;
 use nrf_softdevice::ble::advertisement_builder::{
-    BasicService, Flag, LegacyAdvertisementBuilder, LegacyAdvertisementPayload, ServiceList,
+    Flag, LegacyAdvertisementBuilder, LegacyAdvertisementPayload, ServiceList, ServiceUuid16,
 };
 use nrf_softdevice::ble::{gatt_server, peripheral, Connection};
 use nrf_softdevice::{raw, Softdevice};
@@ -144,12 +144,12 @@ async fn main(spawner: Spawner) {
 
     static ADV_DATA: LegacyAdvertisementPayload = LegacyAdvertisementBuilder::new()
         .flags(&[Flag::GeneralDiscovery])
-        .services_16(ServiceList::Complete, &[BasicService::HealthThermometer])
+        .services_16(ServiceList::Complete, &[ServiceUuid16::HEALTH_THERMOMETER])
         .short_name("HelloRust")
         .build();
 
     static SCAN_DATA: LegacyAdvertisementPayload = LegacyAdvertisementBuilder::new()
-        .services_16(ServiceList::Complete, &[BasicService::HealthThermometer])
+        .services_16(ServiceList::Complete, &[ServiceUuid16::HEALTH_THERMOMETER])
         .build();
 
     loop {

--- a/examples/src/bin/ble_l2cap_peripheral.rs
+++ b/examples/src/bin/ble_l2cap_peripheral.rs
@@ -9,6 +9,9 @@ use core::ptr::NonNull;
 
 use defmt::*;
 use embassy_executor::Spawner;
+use nrf_softdevice::ble::advertisement_builder::{
+    Flag, LegacyAdvertisementBuilder, LegacyAdvertisementPayload, ServiceList,
+};
 use nrf_softdevice::ble::{l2cap, peripheral};
 use nrf_softdevice::{ble, raw, RawError, Softdevice};
 
@@ -115,20 +118,27 @@ async fn main(spawner: Spawner) {
 
     info!("My address: {:?}", ble::get_address(sd));
 
-    #[rustfmt::skip]
-    let adv_data = &[
-        0x02, 0x01, raw::BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE as u8,
-        0x11, 0x06, 0xeb, 0x04, 0x8b, 0xfd, 0x5b, 0x03, 0x21, 0xb5, 0xeb, 0x11, 0x65, 0x2f, 0x18, 0xce, 0x9c, 0x82,
-        0x02, 0x09, b'H',
-    ];
-    #[rustfmt::skip]
-    let scan_data = &[ ];
+    static ADV_DATA: LegacyAdvertisementPayload = LegacyAdvertisementBuilder::new()
+        .flags(&[Flag::GeneralDiscovery, Flag::LE_Only])
+        .services_128(
+            ServiceList::Complete,
+            &[[
+                0xeb, 0x04, 0x8b, 0xfd, 0x5b, 0x03, 0x21, 0xb5, 0xeb, 0x11, 0x65, 0x2f, 0x18, 0xce, 0x9c, 0x82,
+            ]],
+        )
+        .short_name("H")
+        .build();
+
+    static SCAN_DATA: [u8; 0] = [];
 
     let l = l2cap::L2cap::<Packet>::init(sd);
 
     loop {
         let config = peripheral::Config::default();
-        let adv = peripheral::ConnectableAdvertisement::ScannableUndirected { adv_data, scan_data };
+        let adv = peripheral::ConnectableAdvertisement::ScannableUndirected {
+            adv_data: &ADV_DATA,
+            scan_data: &SCAN_DATA,
+        };
         let conn = unwrap!(peripheral::advertise_connectable(sd, adv, &config).await);
 
         info!("advertising done!");

--- a/nrf-softdevice/src/ble/advertisement_builder.rs
+++ b/nrf-softdevice/src/ble/advertisement_builder.rs
@@ -313,7 +313,7 @@ impl<const K: usize> AdvertisementBuilder<K> {
         self.raw(AdvertisementDataType::FULL_NAME, name.as_bytes())
     }
 
-    /// If the full name fits within the remaining space, it is used. Otherwise the short name is used.
+    /// Adds the provided string as a name, truncating and typing as needed.
     ///
     /// *Note: This modifier should be placed last.*
     pub const fn adapt_name(self, name: &str) -> Self {

--- a/nrf-softdevice/src/ble/advertisement_builder.rs
+++ b/nrf-softdevice/src/ble/advertisement_builder.rs
@@ -39,9 +39,7 @@ impl AdvertisementDataType {
     pub const URI: AdvertisementDataType = AdvertisementDataType(0x24);
     pub const LE_SUPPORTED_FEATURES: AdvertisementDataType = AdvertisementDataType(0x27);
     pub const MANUFACTURER_SPECIFIC_DATA: AdvertisementDataType = AdvertisementDataType(0xff);
-}
 
-impl AdvertisementDataType {
     pub const fn from_u8(value: u8) -> Self {
         AdvertisementDataType(value)
     }
@@ -87,77 +85,98 @@ pub enum ServiceList {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(Format))]
-#[repr(u16)]
-pub enum BasicService {
-    GenericAccess = 0x1800,
-    GenericAttribute,
-    ImmediateAlert,
-    LinkLoss,
-    TxPower,
-    CurrentTime,
-    ReferenceTimeUpdate,
-    NextDSTChange,
-    Glucose,
-    HealthThermometer,
-    DeviceInformation,
-    HeartRate = 0x180d,
-    PhoneAlertStatus,
-    Battery,
-    BloodPressure,
-    AlertNotification,
-    HumanInterfaceDevice,
-    ScanParameters,
-    RunnnigSpeedAndCadence,
-    AutomationIO,
-    CyclingSpeedAndCadence,
-    CyclingPower = 0x1818,
-    LocationAndNavigation,
-    EnvironmentalSensing,
-    BodyComposition,
-    UserData,
-    WeightScale,
-    BondManagement,
-    ContinousGlucoseMonitoring,
-    InternetProtocolSupport,
-    IndoorPositioning,
-    PulseOximeter,
-    HTTPProxy,
-    TransportDiscovery,
-    ObjectTransfer,
-    FitnessMachine,
-    MeshProvisioning,
-    MeshProxy,
-    ReconnectionConfiguration,
-    InsulinDelivery = 0x183a,
-    BinarySensor,
-    EmergencyConfiguration,
-    AuthorizationControl,
-    PhysicalActivityMonitor,
-    ElapsedTime,
-    GenericHealthSensor,
-    AudioInputControl = 0x1843,
-    VolumeControl,
-    VolumeOffsetControl,
-    CoordinatedSetIdentification,
-    DeviceTime,
-    MediaControl,
-    GenericMediaControl, // why??
-    ConstantToneExtension,
-    TelephoneBearer,
-    GenericTelephoneBearer,
-    MicrophoneControl,
-    AudioStreamControl,
-    BroadcastAudioScan,
-    PublishedAudioScan,
-    BasicAudioCapabilities,
-    BroadcastAudioAnnouncement,
-    CommonAudio,
-    HearingAccess,
-    TelephonyAndMediaAudio,
-    PublicBroadcastAnnouncement,
-    ElectronicShelfLabel,
-    GamingAudio,
-    MeshProxySolicitation,
+pub struct ServiceUuid16(u16);
+
+impl ServiceUuid16 {
+    pub const GENERIC_ACCESS: ServiceUuid16 = ServiceUuid16(0x1800);
+    pub const GENERIC_ATTRIBUTE: ServiceUuid16 = ServiceUuid16(0x1801);
+    pub const IMMEDIATE_ALERT: ServiceUuid16 = ServiceUuid16(0x1802);
+    pub const LINK_LOSS: ServiceUuid16 = ServiceUuid16(0x1803);
+    pub const TX_POWER: ServiceUuid16 = ServiceUuid16(0x1804);
+    pub const CURRENT_TIME: ServiceUuid16 = ServiceUuid16(0x1805);
+    pub const REFERENCE_TIME_UPDATE: ServiceUuid16 = ServiceUuid16(0x1806);
+    pub const NEXT_DST_CHANGE: ServiceUuid16 = ServiceUuid16(0x1807);
+    pub const GLUCOSE: ServiceUuid16 = ServiceUuid16(0x1808);
+    pub const HEALTH_THERMOMETER: ServiceUuid16 = ServiceUuid16(0x1809);
+    pub const DEVICE_INFORMATION: ServiceUuid16 = ServiceUuid16(0x180A);
+    pub const HEART_RATE: ServiceUuid16 = ServiceUuid16(0x180D);
+    pub const PHONE_ALERT_STATUS: ServiceUuid16 = ServiceUuid16(0x180E);
+    pub const BATTERY: ServiceUuid16 = ServiceUuid16(0x180F);
+    pub const BLOOD_PRESSURE: ServiceUuid16 = ServiceUuid16(0x1810);
+    pub const ALERT_NOTIFICATION: ServiceUuid16 = ServiceUuid16(0x1811);
+    pub const HUMAN_INTERFACE_DEVICE: ServiceUuid16 = ServiceUuid16(0x1812);
+    pub const SCAN_PARAMETERS: ServiceUuid16 = ServiceUuid16(0x1813);
+    pub const RUNNNIG_SPEED_AND_CADENCE: ServiceUuid16 = ServiceUuid16(0x1814);
+    pub const AUTOMATION_IO: ServiceUuid16 = ServiceUuid16(0x1815);
+    pub const CYCLING_SPEED_AND_CADENCE: ServiceUuid16 = ServiceUuid16(0x1816);
+    pub const CYCLING_POWER: ServiceUuid16 = ServiceUuid16(0x1818);
+    pub const LOCATION_AND_NAVIGATION: ServiceUuid16 = ServiceUuid16(0x1819);
+    pub const ENVIRONMENTAL_SENSING: ServiceUuid16 = ServiceUuid16(0x181A);
+    pub const BODY_COMPOSITION: ServiceUuid16 = ServiceUuid16(0x181B);
+    pub const USER_DATA: ServiceUuid16 = ServiceUuid16(0x181C);
+    pub const WEIGHT_SCALE: ServiceUuid16 = ServiceUuid16(0x181D);
+    pub const BOND_MANAGEMENT: ServiceUuid16 = ServiceUuid16(0x181E);
+    pub const CONTINOUS_GLUCOSE_MONITORING: ServiceUuid16 = ServiceUuid16(0x181F);
+    pub const INTERNET_PROTOCOL_SUPPORT: ServiceUuid16 = ServiceUuid16(0x1820);
+    pub const INDOOR_POSITIONING: ServiceUuid16 = ServiceUuid16(0x1821);
+    pub const PULSE_OXIMETER: ServiceUuid16 = ServiceUuid16(0x1822);
+    pub const HTTP_PROXY: ServiceUuid16 = ServiceUuid16(0x1823);
+    pub const TRANSPORT_DISCOVERY: ServiceUuid16 = ServiceUuid16(0x1824);
+    pub const OBJECT_TRANSFER: ServiceUuid16 = ServiceUuid16(0x1825);
+    pub const FITNESS_MACHINE: ServiceUuid16 = ServiceUuid16(0x1826);
+    pub const MESH_PROVISIONING: ServiceUuid16 = ServiceUuid16(0x1827);
+    pub const MESH_PROXY: ServiceUuid16 = ServiceUuid16(0x1828);
+    pub const RECONNECTION_CONFIGURATION: ServiceUuid16 = ServiceUuid16(0x1829);
+    pub const INSULIN_DELIVERY: ServiceUuid16 = ServiceUuid16(0x183A);
+    pub const BINARY_SENSOR: ServiceUuid16 = ServiceUuid16(0x183B);
+    pub const EMERGENCY_CONFIGURATION: ServiceUuid16 = ServiceUuid16(0x183C);
+    pub const AUTHORIZATION_CONTROL: ServiceUuid16 = ServiceUuid16(0x183D);
+    pub const PHYSICAL_ACTIVITY_MONITOR: ServiceUuid16 = ServiceUuid16(0x183E);
+    pub const ELAPSED_TIME: ServiceUuid16 = ServiceUuid16(0x183F);
+    pub const GENERIC_HEALTH_SENSOR: ServiceUuid16 = ServiceUuid16(0x1840);
+    pub const AUDIO_INPUT_CONTROL: ServiceUuid16 = ServiceUuid16(0x1843);
+    pub const VOLUME_CONTROL: ServiceUuid16 = ServiceUuid16(0x1844);
+    pub const VOLUME_OFFSET_CONTROL: ServiceUuid16 = ServiceUuid16(0x1845);
+    pub const COORDINATED_SET_IDENTIFICATION: ServiceUuid16 = ServiceUuid16(0x1846);
+    pub const DEVICE_TIME: ServiceUuid16 = ServiceUuid16(0x1847);
+    pub const MEDIA_CONTROL: ServiceUuid16 = ServiceUuid16(0x1848);
+    pub const GENERIC_MEDIA_CONTROL: ServiceUuid16 = ServiceUuid16(0x1849);
+    pub const CONSTANT_TONE_EXTENSION: ServiceUuid16 = ServiceUuid16(0x184A);
+    pub const TELEPHONE_BEARER: ServiceUuid16 = ServiceUuid16(0x184B);
+    pub const GENERIC_TELEPHONE_BEARER: ServiceUuid16 = ServiceUuid16(0x184C);
+    pub const MICROPHONE_CONTROL: ServiceUuid16 = ServiceUuid16(0x184D);
+    pub const AUDIO_STREAM_CONTROL: ServiceUuid16 = ServiceUuid16(0x184E);
+    pub const BROADCAST_AUDIO_SCAN: ServiceUuid16 = ServiceUuid16(0x184F);
+    pub const PUBLISHED_AUDIO_SCAN: ServiceUuid16 = ServiceUuid16(0x1850);
+    pub const BASIC_AUDIO_CAPABILITIES: ServiceUuid16 = ServiceUuid16(0x1851);
+    pub const BROADCAST_AUDIO_ANNOUNCEMENT: ServiceUuid16 = ServiceUuid16(0x1852);
+    pub const COMMON_AUDIO: ServiceUuid16 = ServiceUuid16(0x1853);
+    pub const HEARING_ACCESS: ServiceUuid16 = ServiceUuid16(0x1854);
+    pub const TELEPHONY_AND_MEDIA_AUDIO: ServiceUuid16 = ServiceUuid16(0x1855);
+    pub const PUBLIC_BROADCAST_ANNOUNCEMENT: ServiceUuid16 = ServiceUuid16(0x1856);
+    pub const ELECTRONIC_SHELF_LABEL: ServiceUuid16 = ServiceUuid16(0x1847);
+    pub const GAMING_AUDIO: ServiceUuid16 = ServiceUuid16(0x1858);
+    pub const MESH_PROXY_SOLICITATION: ServiceUuid16 = ServiceUuid16(0x1859);
+
+    pub const fn from_u16(value: u16) -> Self {
+        ServiceUuid16(value)
+    }
+
+    pub const fn to_u16(self) -> u16 {
+        self.0
+    }
+}
+
+impl From<u16> for ServiceUuid16 {
+    fn from(value: u16) -> Self {
+        ServiceUuid16(value)
+    }
+}
+
+impl From<ServiceUuid16> for u16 {
+    fn from(value: ServiceUuid16) -> Self {
+        value.0
+    }
 }
 
 pub struct AdvertisementBuilder<const N: usize> {
@@ -250,7 +269,7 @@ impl<const K: usize> AdvertisementBuilder<K> {
     }
 
     /// Add a list of 16-bit service uuids to the advertisement data.
-    pub const fn services_16(self, complete: ServiceList, services: &[BasicService]) -> Self {
+    pub const fn services_16(self, complete: ServiceList, services: &[ServiceUuid16]) -> Self {
         let ad_type = match complete {
             ServiceList::Incomplete => AdvertisementDataType::INCOMPLETE_16_SERVICE_LIST,
             ServiceList::Complete => AdvertisementDataType::COMPLETE_16_SERVICE_LIST,
@@ -259,7 +278,7 @@ impl<const K: usize> AdvertisementBuilder<K> {
         let mut res = self.write(&[(services.len() * 2) as u8 + 1, ad_type.to_u8()]);
         let mut i = 0;
         while i < services.len() {
-            res = res.write(&(services[i] as u16).to_le_bytes());
+            res = res.write(&(services[i].to_u16()).to_le_bytes());
             i += 1;
         }
         res

--- a/nrf-softdevice/src/ble/advertisement_builder.rs
+++ b/nrf-softdevice/src/ble/advertisement_builder.rs
@@ -1,49 +1,75 @@
 #[cfg(feature = "defmt")]
 use defmt::Format;
 
-const STD_LEN: usize = 31;
-const EXT_LEN: usize = 254;
+const LEGACY_PAYLOAD_LEN: usize = 31;
+const EXTENDED_PAYLOAD_LEN: usize = 254;
 
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(Format))]
 pub enum Error {
     Oversize { expected: usize },
 }
 
-#[allow(non_camel_case_types)]
-#[repr(u8)]
-pub enum ADType {
-    Flags = 0x01,
-    Incomplete16ServiceList,
-    Complete16ServiceList,
-    Incomplete32ServiceList,
-    Complete32ServiceList,
-    Incomplete128ServiceList,
-    Complete128ServiceList,
-    ShortName,
-    FullName,
-    TXPowerLevel,
-    PeripheralConnectionIntervalRange = 0x12,
-    ServiceSolicitation16 = 0x14,
-    ServiceSolicitation128,
-    ServiceSolicitation32 = 0x1f,
-    ServiceData16 = 0x16,
-    ServiceData32 = 0x20,
-    ServiceData128,
-    Appearance = 0x19,
-    PublicTargetAddress = 0x17,
-    RandomTargetAddress,
-    AdvertisingInterval = 0x1a,
-    URI = 0x24,
-    LE_SupportedFeatures = 0x27,
-    ManufacturerSpecificData = 0xff,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(Format))]
+pub struct AdvertisementDataType(u8);
+
+impl AdvertisementDataType {
+    pub const FLAGS: AdvertisementDataType = AdvertisementDataType(0x01);
+    pub const INCOMPLETE_16_SERVICE_LIST: AdvertisementDataType = AdvertisementDataType(0x02);
+    pub const COMPLETE_16_SERVICE_LIST: AdvertisementDataType = AdvertisementDataType(0x03);
+    pub const INCOMPLETE_32_SERVICE_LIST: AdvertisementDataType = AdvertisementDataType(0x04);
+    pub const COMPLETE_32_SERVICE_LIST: AdvertisementDataType = AdvertisementDataType(0x05);
+    pub const INCOMPLETE_128_SERVICE_LIST: AdvertisementDataType = AdvertisementDataType(0x06);
+    pub const COMPLETE_128_SERVICE_LIST: AdvertisementDataType = AdvertisementDataType(0x07);
+    pub const SHORT_NAME: AdvertisementDataType = AdvertisementDataType(0x08);
+    pub const FULL_NAME: AdvertisementDataType = AdvertisementDataType(0x09);
+    pub const TXPOWER_LEVEL: AdvertisementDataType = AdvertisementDataType(0x0a);
+    pub const PERIPHERAL_CONNECTION_INTERVAL_RANGE: AdvertisementDataType = AdvertisementDataType(0x12);
+    pub const SERVICE_SOLICITATION_16: AdvertisementDataType = AdvertisementDataType(0x14);
+    pub const SERVICE_SOLICITATION_128: AdvertisementDataType = AdvertisementDataType(0x15);
+    pub const SERVICE_SOLICITATION_32: AdvertisementDataType = AdvertisementDataType(0x1f);
+    pub const SERVICE_DATA_16: AdvertisementDataType = AdvertisementDataType(0x16);
+    pub const SERVICE_DATA_32: AdvertisementDataType = AdvertisementDataType(0x20);
+    pub const SERVICE_DATA_128: AdvertisementDataType = AdvertisementDataType(0x21);
+    pub const APPEARANCE: AdvertisementDataType = AdvertisementDataType(0x19);
+    pub const PUBLIC_TARGET_ADDRESS: AdvertisementDataType = AdvertisementDataType(0x17);
+    pub const RANDOM_TARGET_ADDRESS: AdvertisementDataType = AdvertisementDataType(0x18);
+    pub const ADVERTISING_INTERVAL: AdvertisementDataType = AdvertisementDataType(0x1a);
+    pub const URI: AdvertisementDataType = AdvertisementDataType(0x24);
+    pub const LE_SUPPORTED_FEATURES: AdvertisementDataType = AdvertisementDataType(0x27);
+    pub const MANUFACTURER_SPECIFIC_DATA: AdvertisementDataType = AdvertisementDataType(0xff);
 }
 
-#[allow(non_camel_case_types)]
-#[derive(Clone, Copy)]
+impl AdvertisementDataType {
+    pub const fn from_u8(value: u8) -> Self {
+        AdvertisementDataType(value)
+    }
+
+    pub const fn to_u8(self) -> u8 {
+        self.0
+    }
+}
+
+impl From<u8> for AdvertisementDataType {
+    fn from(value: u8) -> Self {
+        AdvertisementDataType(value)
+    }
+}
+
+impl From<AdvertisementDataType> for u8 {
+    fn from(value: AdvertisementDataType) -> Self {
+        value.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(Format))]
 #[repr(u8)]
 pub enum Flag {
     LimitedDiscovery = 0b1,
     GeneralDiscovery = 0b10,
+    #[allow(non_camel_case_types)]
     LE_Only = 0b100,
 
     // i don't understand these but in case people want them
@@ -52,19 +78,15 @@ pub enum Flag {
     // the rest are "reserved for future use"
 }
 
-pub trait Service {
-    const SIZE: usize;
-
-    fn render<const N: usize>(self, adv: &mut AdvertisementData<N>);
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(Format))]
+pub enum ServiceList {
+    Incomplete,
+    Complete,
 }
 
-pub trait ServiceList<S: Service, const N: usize> {
-    const AD: ADType;
-
-    fn list(self) -> [S; N];
-}
-
-#[derive(Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(Format))]
 #[repr(u16)]
 pub enum BasicService {
     GenericAccess = 0x1800,
@@ -138,145 +160,163 @@ pub enum BasicService {
     MeshProxySolicitation,
 }
 
-impl Service for BasicService {
-    const SIZE: usize = 2;
-
-    fn render<const N: usize>(self, adv: &mut AdvertisementData<N>) {
-        let data = (self as u16).swap_bytes().to_be_bytes();
-        adv.write(&data);
-    }
-}
-
-pub struct CustomService(pub [u8; 16]);
-
-impl Service for CustomService {
-    const SIZE: usize = 16;
-
-    fn render<const N: usize>(mut self, adv: &mut AdvertisementData<N>) {
-        self.0.reverse();
-        adv.write(&self.0);
-    }
-}
-
-pub struct Incomplete16<const N: usize>(pub [BasicService; N]);
-pub struct Complete16<const N: usize>(pub [BasicService; N]);
-pub struct Incomplete128<const N: usize>(pub [CustomService; N]);
-pub struct Complete128<const N: usize>(pub [CustomService; N]);
-
-macro_rules! impl_service_list {
-    ($LIST:ident, $SERVICE:ident, $AD:ident) => {
-        impl<const N: usize> ServiceList<$SERVICE, N> for $LIST<N> {
-            const AD: ADType = ADType::$AD;
-
-            fn list(self) -> [$SERVICE; N] {
-                self.0
-            }
-        }
-    };
-}
-
-impl_service_list!(Incomplete16, BasicService, Incomplete16ServiceList);
-impl_service_list!(Complete16, BasicService, Complete16ServiceList);
-impl_service_list!(Incomplete128, CustomService, Incomplete128ServiceList);
-impl_service_list!(Complete128, CustomService, Complete128ServiceList);
-
-pub trait Name {
-    const AD: ADType;
-
-    fn inner(&self) -> &str;
-}
-
-pub struct ShortName<'a>(pub &'a str);
-pub struct FullName<'a>(pub &'a str);
-
-macro_rules! impl_name {
-    ($NAME:ident, $AD:ident) => {
-        impl<'a> Name for $NAME<'a> {
-            const AD: ADType = ADType::$AD;
-
-            fn inner(&self) -> &str {
-                self.0
-            }
-        }
-    };
-}
-
-impl_name!(ShortName, ShortName);
-impl_name!(FullName, FullName);
-
-pub struct AdvertisementData<const N: usize> {
+pub struct AdvertisementBuilder<const N: usize> {
     buf: [u8; N],
     ptr: usize,
 }
 
-impl<const K: usize> AdvertisementData<K> {
-    pub fn new() -> Self {
+pub struct AdvertisementPayload<const N: usize> {
+    buf: [u8; N],
+    len: usize,
+}
+
+impl<const N: usize> AsRef<[u8]> for AdvertisementPayload<N> {
+    fn as_ref(&self) -> &[u8] {
+        &self.buf[..self.len]
+    }
+}
+
+impl<const N: usize> core::ops::Deref for AdvertisementPayload<N> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.buf[..self.len]
+    }
+}
+
+impl<const K: usize> AdvertisementBuilder<K> {
+    pub const fn new() -> Self {
         Self { buf: [0; K], ptr: 0 }
     }
 
-    fn write(&mut self, data: &[u8]) {
+    const fn write(mut self, data: &[u8]) -> Self {
         let end = self.ptr + data.len();
 
-        if end <= K {
-            self.buf[self.ptr..end].copy_from_slice(data);
+        let mut i = 0;
+        while self.ptr < K && i < data.len() {
+            self.buf[self.ptr] = data[i];
+            i += 1;
+            self.ptr += 1;
         }
 
-        self.ptr += data.len();
+        self.ptr = end;
+        self
     }
 
     /// Write raw bytes to the advertisement data.
     ///
     /// *Note: The length is automatically computed and prepended.*
-    pub fn raw(mut self, ad: ADType, data: &[u8]) -> Self {
-        self.write(&[data.len() as u8 + 1, ad as u8]);
-        self.write(data);
-
-        self
+    pub const fn raw(self, ad: AdvertisementDataType, data: &[u8]) -> Self {
+        self.write(&[data.len() as u8 + 1, ad.to_u8()]).write(data)
     }
 
-    /// View the resulting advertisement data in the form of a byte slice.
-    pub fn as_slice(&self) -> Result<&[u8], Error> {
-        (self.ptr <= K)
-            .then(|| &self.buf[..self.ptr])
-            .ok_or(Error::Oversize { expected: self.ptr })
+    /// Get the resulting advertisement payload.
+    ///
+    /// Returns `Error::Oversize` if more than `K` bytes were written to the builder.
+    pub const fn try_build(self) -> Result<AdvertisementPayload<K>, Error> {
+        if self.ptr <= K {
+            Ok(AdvertisementPayload {
+                buf: self.buf,
+                len: self.ptr,
+            })
+        } else {
+            Err(Error::Oversize { expected: self.ptr })
+        }
+    }
+
+    /// Get the resulting advertisement payload.
+    ///
+    /// Panics if more than `K` bytes were written to the builder.
+    pub const fn build(self) -> AdvertisementPayload<K> {
+        // Use core::assert! even if defmt is enabled because it is const
+        core::assert!(self.ptr <= K, "advertisement exceeded buffer length");
+
+        AdvertisementPayload {
+            buf: self.buf,
+            len: self.ptr,
+        }
     }
 
     /// Add flags to the advertisement data.
-    pub fn flags<const N: usize>(self, flags: [Flag; N]) -> Self {
-        let result = flags.iter().fold(0, |partial, &flag| partial + flag as u8);
-
-        self.raw(ADType::Flags, &[result])
-    }
-
-    /// Add a list of services to the advertisement data.
-    pub fn services<L: ServiceList<S, N>, S: Service, const N: usize>(mut self, services: L) -> Self {
-        self.write(&[(N * S::SIZE) as u8 + 1, L::AD as u8]);
-
-        for service in services.list() {
-            service.render(&mut self);
+    pub const fn flags(self, flags: &[Flag]) -> Self {
+        let mut i = 0;
+        let mut bits = 0;
+        while i < flags.len() {
+            bits |= flags[i] as u8;
+            i += 1;
         }
 
-        self
+        self.raw(AdvertisementDataType::FLAGS, &[bits])
+    }
+
+    /// Add a list of 16-bit service uuids to the advertisement data.
+    pub const fn services_16(self, complete: ServiceList, services: &[BasicService]) -> Self {
+        let ad_type = match complete {
+            ServiceList::Incomplete => AdvertisementDataType::INCOMPLETE_16_SERVICE_LIST,
+            ServiceList::Complete => AdvertisementDataType::COMPLETE_16_SERVICE_LIST,
+        };
+
+        let mut res = self.write(&[(services.len() * 2) as u8 + 1, ad_type.to_u8()]);
+        let mut i = 0;
+        while i < services.len() {
+            res = res.write(&(services[i] as u16).to_le_bytes());
+            i += 1;
+        }
+        res
+    }
+
+    /// Add a list of 128-bit service uuids to the advertisement data.
+    ///
+    /// Note that each UUID in the list needs to be in little-endian format, i.e. opposite to what you would
+    /// normally write UUIDs.
+    pub const fn services_128(self, complete: ServiceList, services: &[[u8; 16]]) -> Self {
+        let ad_type = match complete {
+            ServiceList::Incomplete => AdvertisementDataType::INCOMPLETE_128_SERVICE_LIST,
+            ServiceList::Complete => AdvertisementDataType::COMPLETE_128_SERVICE_LIST,
+        };
+
+        let mut res = self.write(&[(services.len() * 16) as u8 + 1, ad_type.to_u8()]);
+        let mut i = 0;
+        while i < services.len() {
+            res = res.write(&services[i]);
+            i += 1;
+        }
+        res
     }
 
     /// Add a name to the advertisement data.
-    pub fn name<N: Name>(self, name: N) -> Self {
-        self.raw(N::AD, name.inner().as_bytes())
+    pub const fn short_name(self, name: &str) -> Self {
+        self.raw(AdvertisementDataType::SHORT_NAME, name.as_bytes())
+    }
+
+    /// Add a name to the advertisement data.
+    pub const fn full_name(self, name: &str) -> Self {
+        self.raw(AdvertisementDataType::FULL_NAME, name.as_bytes())
     }
 
     /// If the full name fits within the remaining space, it is used. Otherwise the short name is used.
     ///
     /// *Note: This modifier should be placed last.*
-    pub fn adapt_name(self, full: FullName, short: ShortName) -> Self {
-        let full_len = full.inner().len();
-
-        if self.ptr + full_len <= K {
-            self.name(full)
+    pub const fn adapt_name(self, name: &str) -> Self {
+        let p = self.ptr;
+        if p + 2 + name.len() <= K {
+            self.full_name(name)
         } else {
-            self.name(short)
+            let mut res = self.write(&[(K - p) as u8, AdvertisementDataType::SHORT_NAME.to_u8()]);
+            let mut i: usize = 0;
+            let bytes = name.as_bytes();
+            while res.ptr < K {
+                res.buf[res.ptr] = bytes[i];
+                res.ptr += 1;
+                i += 1;
+            }
+            res
         }
     }
 }
 
-pub type StandardAdvertisementData = AdvertisementData<STD_LEN>;
-pub type ExtendedAdvertisementData = AdvertisementData<EXT_LEN>;
+pub type LegacyAdvertisementBuilder = AdvertisementBuilder<LEGACY_PAYLOAD_LEN>;
+pub type ExtendedAdvertisementBuilder = AdvertisementBuilder<EXTENDED_PAYLOAD_LEN>;
+
+pub type LegacyAdvertisementPayload = AdvertisementPayload<LEGACY_PAYLOAD_LEN>;
+pub type ExtendedAdvertisementPayload = AdvertisementPayload<EXTENDED_PAYLOAD_LEN>;

--- a/nrf-softdevice/src/ble/advertisement_builder.rs
+++ b/nrf-softdevice/src/ble/advertisement_builder.rs
@@ -209,17 +209,27 @@ impl<const K: usize> AdvertisementBuilder<K> {
     }
 
     const fn write(mut self, data: &[u8]) -> Self {
-        let end = self.ptr + data.len();
-
-        let mut i = 0;
-        while self.ptr < K && i < data.len() {
-            self.buf[self.ptr] = data[i];
-            i += 1;
-            self.ptr += 1;
+        if self.ptr + data.len() <= K {
+            let mut i = 0;
+            while i < data.len() {
+                self.buf[self.ptr] = data[i];
+                i += 1;
+                self.ptr += 1;
+            }
+        } else {
+            // Overflow, but still track how much data was attempted to be written
+            self.ptr += data.len();
         }
 
-        self.ptr = end;
         self
+    }
+
+    pub const fn capacity() -> usize {
+        K
+    }
+
+    pub const fn len(&self) -> usize {
+        self.ptr
     }
 
     /// Write raw bytes to the advertisement data.

--- a/nrf-softdevice/src/ble/mod.rs
+++ b/nrf-softdevice/src/ble/mod.rs
@@ -33,10 +33,10 @@ pub mod gatt_server;
 #[cfg(feature = "ble-l2cap")]
 pub mod l2cap;
 
+use core::mem;
+
 #[cfg(any(feature = "ble-gatt-server", feature = "ble-sec"))]
 pub use replies::*;
-
-use core::mem;
 
 use crate::{raw, RawError, Softdevice};
 


### PR DESCRIPTION
I got nerd sniped into seeing if the advertisement builder API by @AdinAck in #214 could be made fully const. It turns out the answer is yes, though it required removing the traits (traits are generally not compatible with const fns) and making a few other refactorings as a result. I also changed the `ADType` enum to an `AdvertisementDataType` newtype with associated constants, to allow users to use values that may be standardized later.