### PR TITLE
macro/dep: disable uuid default features

### DIFF
--- a/nrf-softdevice-macro/Cargo.toml
+++ b/nrf-softdevice-macro/Cargo.toml
@@ -11,7 +11,7 @@ quote = "1.0.7"
 darling = "0.13.4"
 proc-macro2 = "1.0.18"
 Inflector = "0.11.4"
-uuid = "1.2.2"
+uuid = { version = "1.2.2", default-features = false }
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
The `nrf-softdevice-macro` crate pulls in `uuid`'s `std` feature in dependent projects because it doesn't disable `default-features`. 

E.g. if I have this:

```toml
# Cargo.toml

[dependencies]
uuid = { version = "*", default-features = false } # intending to disable `std`
nrf-softdevice-macro = "*"
```

I end up with a compiler error because of the way features are resolved:

```
$ cargo build
... 
   Compiling uuid v1.6.1
error[E0463]: can't find crate for `std`
    |
222 | extern crate std;
    | ^^^^^^^^^^^^^^^^^ can't find crate
    |
    = note: the `thumbv7em-none-eabi` target may not support the standard library
    = help: consider building the standard library from source with `cargo build -Zbuild-std`
```

This patch sets `default-features = false` for this dep.