### PR TITLE
Fix compilation error for nRF52805

### DIFF
--- a/nrf-softdevice/src/critical_section_impl.rs
+++ b/nrf-softdevice/src/critical_section_impl.rs
@@ -3,7 +3,7 @@ use core::sync::atomic::{compiler_fence, AtomicBool, Ordering};
 
 use crate::pac::{Interrupt, NVIC};
 
-#[cfg(any(feature = "nrf52810", feature = "nrf52811"))]
+#[cfg(any(feature = "nrf52805", feature = "nrf52810", feature = "nrf52811"))]
 const RESERVED_IRQS: u32 = (1 << (Interrupt::POWER_CLOCK as u8))
     | (1 << (Interrupt::RADIO as u8))
     | (1 << (Interrupt::RTC0 as u8))
@@ -14,7 +14,7 @@ const RESERVED_IRQS: u32 = (1 << (Interrupt::POWER_CLOCK as u8))
     | (1 << (Interrupt::TEMP as u8))
     | (1 << (Interrupt::SWI5 as u8));
 
-#[cfg(not(any(feature = "nrf52810", feature = "nrf52811")))]
+#[cfg(not(any(feature = "nrf52805", feature = "nrf52810", feature = "nrf52811")))]
 const RESERVED_IRQS: u32 = (1 << (Interrupt::POWER_CLOCK as u8))
     | (1 << (Interrupt::RADIO as u8))
     | (1 << (Interrupt::RTC0 as u8))


### PR DESCRIPTION
When trying to build with `nrf52805` feature, I got the following error:

```
error[E0599]: no variant or associated item named `SWI5_EGU5` found for enum `Interrupt` in the current scope
  --> .../nrf-softdevice-0.1.0/src/critical_section_impl.rs:26:25
   |
26 |     | (1 << (Interrupt::SWI5_EGU5 as u8));
   |                         ^^^^^^^^^
   |                         |
   |                         variant or associated item not found in `Interrupt`
   |                         help: there is a variant with a similar name: `SWI0_EGU0`

For more information about this error, try `rustc --explain E0599`.
error: could not compile `nrf-softdevice` (lib) due to 1 previous error

```

The fix verified to work in hardware on a nRF52805-based board.