### PR TITLE
Create a separate portal for receiving notification events

### DIFF
--- a/nrf-softdevice/src/ble/connection.rs
+++ b/nrf-softdevice/src/ble/connection.rs
@@ -224,6 +224,8 @@ impl ConnectionState {
         // Signal possible in-progess operations that the connection has disconnected.
         #[cfg(feature = "ble-gatt-client")]
         crate::ble::gatt_client::portal(conn_handle).call(_ble_evt);
+        #[cfg(feature = "ble-gatt-client")]
+        crate::ble::gatt_client::hvx_portal(conn_handle).call(_ble_evt);
         #[cfg(feature = "ble-gatt-server")]
         crate::ble::gatt_server::portal(conn_handle).call(_ble_evt);
         #[cfg(feature = "ble-l2cap")]


### PR DESCRIPTION
If `gatt_client::run` shares a portal with the other `gatt_client` methods (e.g. `read`, `write`, etc), it is not possible to concurrently receive notifications on a connection while using any other `gatt_client` methods.