### PR TITLE
Make data length updates optional

### DIFF
--- a/nrf-softdevice/src/ble/central.rs
+++ b/nrf-softdevice/src/ble/central.rs
@@ -98,12 +98,7 @@ where
                     debug!("connected role={:?} peer_addr={:?}", role, peer_address);
 
                     match new_conn(conn_handle, role, peer_address, conn_params) {
-                        Ok(conn) => {
-                            #[cfg(any(feature = "s113", feature = "s132", feature = "s140"))]
-                            crate::ble::gap::do_data_length_update(conn_handle, ptr::null());
-
-                            Ok(conn)
-                        }
+                        Ok(conn) => Ok(conn),
                         Err(_) => {
                             raw::sd_ble_gap_disconnect(
                                 conn_handle,

--- a/nrf-softdevice/src/ble/connection.rs
+++ b/nrf-softdevice/src/ble/connection.rs
@@ -63,6 +63,25 @@ impl From<RawError> for IgnoreSlaveLatencyError {
     }
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum DataLengthUpdateError {
+    Disconnected,
+    Raw(RawError),
+}
+
+impl From<DisconnectedError> for DataLengthUpdateError {
+    fn from(_err: DisconnectedError) -> Self {
+        Self::Disconnected
+    }
+}
+
+impl From<RawError> for DataLengthUpdateError {
+    fn from(err: RawError) -> Self {
+        Self::Raw(err)
+    }
+}
+
 pub enum PhyUpdateError {
     Disconnected,
     Raw(RawError),
@@ -541,6 +560,44 @@ impl Connection {
 
     pub fn iter() -> ConnectionIter {
         ConnectionIter(0)
+    }
+
+    /// Initiate a Data Length Update procedure.
+    ///
+    /// Note that this just initiates the data length update, it does not wait for completion.
+    /// Immediately after return, the active data length will still be the old one, and after some time they
+    /// should change to the new ones.
+    #[cfg(any(feature = "s113", feature = "s132", feature = "s140"))]
+    pub fn data_length_update(
+        &mut self,
+        params: Option<&raw::ble_gap_data_length_params_t>,
+    ) -> Result<raw::ble_gap_data_length_limitation_t, DataLengthUpdateError> {
+        let conn_handle = self.with_state(|state| state.check_connected())?;
+
+        let params = params.map(core::ptr::from_ref).unwrap_or(core::ptr::null());
+        let mut dl_limitation = unsafe { core::mem::zeroed() };
+        let ret = unsafe { raw::sd_ble_gap_data_length_update(conn_handle, params, &mut dl_limitation) };
+
+        if let Err(err) = RawError::convert(ret) {
+            warn!("sd_ble_gap_data_length_update err {:?}", err);
+            return Err(err.into());
+        }
+
+        if dl_limitation.tx_payload_limited_octets != 0 || dl_limitation.rx_payload_limited_octets != 0 {
+            warn!(
+                "The requested TX/RX packet length is too long by {:?}/{:?} octets.",
+                dl_limitation.tx_payload_limited_octets, dl_limitation.rx_payload_limited_octets
+            );
+        }
+
+        if dl_limitation.tx_rx_time_limited_us != 0 {
+            warn!(
+                "The requested combination of TX and RX packet lengths is too long by {:?} us",
+                dl_limitation.tx_rx_time_limited_us
+            );
+        }
+
+        Ok(dl_limitation)
     }
 
     /// Send a request to the connected device to change the PHY.

--- a/nrf-softdevice/src/ble/peripheral.rs
+++ b/nrf-softdevice/src/ble/peripheral.rs
@@ -370,12 +370,7 @@ where
                     debug!("connected role={:?} peer_addr={:?}", role, peer_address);
 
                     match f(conn_handle, role, peer_address, conn_params) {
-                        Ok(conn) => {
-                            #[cfg(any(feature = "s113", feature = "s132", feature = "s140"))]
-                            gap::do_data_length_update(conn_handle, ptr::null());
-
-                            Ok(conn)
-                        }
+                        Ok(conn) => Ok(conn),
                         Err(_) => {
                             raw::sd_ble_gap_disconnect(
                                 conn_handle,


### PR DESCRIPTION
No longer initiate the data length update procedure immediately after connection. Instead, provide a `data_length_update` method on `Connection` to allow the application to choose whether and with what parameters to perform the data length update.