### PR TITLE
msrv: Require at least Rust 1.76

### DIFF
--- a/nrf-softdevice/Cargo.toml
+++ b/nrf-softdevice/Cargo.toml
@@ -8,6 +8,7 @@ description = "Rust interface to nRF SoftDevice"
 repository = "https://github.com/embassy-rs/nrf-softdevice"
 categories = ["embedded", "hardware-support", "no-std"]
 keywords = ["arm", "cortex-m", "nrf52", "nrf-softdevice"]
+rust = "1.76"
 
 [features]
 


### PR DESCRIPTION
Commit d26f70e9 introduced `core::ptr::from_ref` usage, which was stabilized in 1.76.