### PR TITLE
msrv: Use correct `rust-version` field for msrv

### DIFF
--- a/nrf-softdevice/Cargo.toml
+++ b/nrf-softdevice/Cargo.toml
@@ -8,7 +8,7 @@ description = "Rust interface to nRF SoftDevice"
 repository = "https://github.com/embassy-rs/nrf-softdevice"
 categories = ["embedded", "hardware-support", "no-std"]
 keywords = ["arm", "cortex-m", "nrf52", "nrf-softdevice"]
-rust = "1.76"
+rust-version = "1.76"
 
 [features]
 


### PR DESCRIPTION
Not sure where the original `rust = ...` came from...
https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field