### PR TITLE
fix(FixedGattValue): avoid misaligned data access for Primitive

### DIFF
--- a/nrf-softdevice/src/ble/gatt_traits.rs
+++ b/nrf-softdevice/src/ble/gatt_traits.rs
@@ -66,7 +66,7 @@ impl<T: Primitive> FixedGattValue for T {
         if data.len() != Self::SIZE {
             panic!("Bad len")
         }
-        unsafe { *(data.as_ptr() as *const Self) }
+        unsafe { (data.as_ptr() as *const Self).read_unaligned() }
     }
 
     fn to_gatt(&self) -> &[u8] {


### PR DESCRIPTION
Fixes #253 