### PR TITLE
Fix probe-rs "--binary-format" -> "--format" argument in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Flashing the softdevice is required. It is NOT part of the built binary. You onl
 - As a debug client, if you are using
   - probe-rs:
     - Erase the flash with `probe-rs erase --chip nrf52840_xxAA` (You may have to supply additional `--allow-erase-all` argument).
-    - Flash the SoftDevice with `probe-rs download --verify --binary-format hex --chip nRF52840_xxAA s140_nrf52_7.X.X_softdevice.hex`
+    - Flash the SoftDevice with `probe-rs download --verify --format hex --chip nRF52840_xxAA s140_nrf52_7.X.X_softdevice.hex`
   - nrfjprog:
     - Flash the SoftDevice with `nrfjprog --family NRF52 --chiperase --verify --program s140_nrf52_7.0.1_softdevice.hex`
 


### PR DESCRIPTION
In the latest version of probe-rs (23.0) the argument is now called "format". The Readme seems to be based on an older version of probe.

Helptext:
```
      --format <FORMAT>
          If a format is provided, use it. If a target has a preferred format, we use that. Finally, if neither of the above cases are true, we default to ELF
```