### PR TITLE
Remove dependency on the PAC.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,19 +1,17 @@
 {
   "editor.formatOnSave": true,
-  "rust-analyzer.cargo.allFeatures": false,
-  "rust-analyzer.checkOnSave.allFeatures": false,
+  "rust-analyzer.imports.granularity.group": "module",
+  "rust-analyzer.cargo.allTargets": false,
   "rust-analyzer.cargo.target": "thumbv7em-none-eabihf",
-  "rust-analyzer.checkOnSave.allTargets": false,
-  "rust-analyzer.procMacro.enable": true,
   "rust-analyzer.linkedProjects": [
     "examples/Cargo.toml"
+  ],
+  "rust-analyzer.cargo.features": [
+    "nrf52840-dk"
   ],
   "files.watcherExclude": {
     "**/.git/objects/**": true,
     "**/.git/subtree-cache/**": true,
     "**/target/**": true,
   },
-  "rust-analyzer.imports.granularity.group": "module",
-  "rust-analyzer.cargo.buildScripts.enable": true,
-  "rust-analyzer.procMacro.attributes.enable": false,
 }

--- a/ci.sh
+++ b/ci.sh
@@ -2,6 +2,8 @@
 
 set -euxo pipefail
 
+export RUSTFLAGS=-Dwarnings
+
 # Build examples
 #===============
 

--- a/nrf-softdevice/Cargo.toml
+++ b/nrf-softdevice/Cargo.toml
@@ -12,13 +12,13 @@ rust-version = "1.76"
 
 [features]
 
-nrf52805 = ["nrf52805-pac"]
-nrf52810 = ["nrf52810-pac"]
-nrf52811 = ["nrf52811-pac"]
-nrf52820 = ["nrf52820-pac"]
-nrf52832 = ["nrf52832-pac"]
-nrf52833 = ["nrf52833-pac"]
-nrf52840 = ["nrf52840-pac"]
+nrf52805 = []
+nrf52810 = []
+nrf52811 = []
+nrf52820 = []
+nrf52832 = []
+nrf52833 = []
+nrf52840 = []
 
 s112 = ["nrf-softdevice-s112"]
 s113 = ["nrf-softdevice-s113"]
@@ -56,20 +56,11 @@ num_enum = { version = "0.7.0", default-features = false }
 embassy-sync = { version = "0.6.0" }
 embassy-futures = { version = "0.1.1" }
 cortex-m = "0.7.2"
-cortex-m-rt = ">=0.6.15,<0.8"
 heapless = "0.8.0"
 fixed = "1.5.0"
 futures = { version = "0.3.17", default-features = false }
 embedded-storage = "0.3.1"
 embedded-storage-async = { version = "0.4.1" }
-
-nrf52805-pac  = { version = "0.12.0", features = ["rt"], optional = true }
-nrf52810-pac  = { version = "0.12.0", features = ["rt"], optional = true }
-nrf52811-pac  = { version = "0.12.0", features = ["rt"], optional = true }
-nrf52820-pac  = { version = "0.12.0", features = ["rt"], optional = true }
-nrf52832-pac  = { version = "0.12.0", features = ["rt"], optional = true }
-nrf52833-pac  = { version = "0.12.0", features = ["rt"], optional = true }
-nrf52840-pac  = { version = "0.12.0", features = ["rt"], optional = true }
 
 nrf-softdevice-s112 = { version = "0.1.1", path = "../nrf-softdevice-s112", optional = true }
 nrf-softdevice-s113 = { version = "0.1.1", path = "../nrf-softdevice-s113", optional = true }

--- a/nrf-softdevice/src/critical_section_impl.rs
+++ b/nrf-softdevice/src/critical_section_impl.rs
@@ -1,20 +1,10 @@
 use core::arch::asm;
 use core::sync::atomic::{compiler_fence, AtomicBool, Ordering};
 
-use crate::pac::{Interrupt, NVIC};
+use cortex_m::peripheral::NVIC;
 
-#[cfg(any(feature = "nrf52805", feature = "nrf52810", feature = "nrf52811"))]
-const RESERVED_IRQS: u32 = (1 << (Interrupt::POWER_CLOCK as u8))
-    | (1 << (Interrupt::RADIO as u8))
-    | (1 << (Interrupt::RTC0 as u8))
-    | (1 << (Interrupt::TIMER0 as u8))
-    | (1 << (Interrupt::RNG as u8))
-    | (1 << (Interrupt::ECB as u8))
-    | (1 << (Interrupt::CCM_AAR as u8))
-    | (1 << (Interrupt::TEMP as u8))
-    | (1 << (Interrupt::SWI5 as u8));
+use crate::Interrupt;
 
-#[cfg(not(any(feature = "nrf52805", feature = "nrf52810", feature = "nrf52811")))]
 const RESERVED_IRQS: u32 = (1 << (Interrupt::POWER_CLOCK as u8))
     | (1 << (Interrupt::RADIO as u8))
     | (1 << (Interrupt::RTC0 as u8))

--- a/nrf-softdevice/src/events.rs
+++ b/nrf-softdevice/src/events.rs
@@ -5,7 +5,6 @@ use embassy_sync::waitqueue::AtomicWaker;
 use futures::future::poll_fn;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 
-use crate::pac::interrupt;
 use crate::{raw, RawError};
 
 static SWI2_SOC_EVT_WAKER: AtomicWaker = AtomicWaker::new();
@@ -100,16 +99,15 @@ pub(crate) async fn run_ble() -> ! {
     .await
 }
 
-#[cfg(any(feature = "nrf52805", feature = "nrf52810", feature = "nrf52811"))]
-#[interrupt]
-unsafe fn SWI2() {
-    SWI2_SOC_EVT_WAKER.wake();
-    SWI2_BLE_EVT_WAKER.wake();
-}
-
-#[cfg(not(any(feature = "nrf52805", feature = "nrf52810", feature = "nrf52811")))]
-#[interrupt]
-unsafe fn SWI2_EGU2() {
+#[cfg_attr(
+    any(feature = "nrf52805", feature = "nrf52810", feature = "nrf52811"),
+    export_name = "SWI2"
+)]
+#[cfg_attr(
+    not(any(feature = "nrf52805", feature = "nrf52810", feature = "nrf52811")),
+    export_name = "SWI2_EGU2"
+)]
+unsafe extern "C" fn swi2_irq_handler() {
     SWI2_SOC_EVT_WAKER.wake();
     SWI2_BLE_EVT_WAKER.wake();
 }

--- a/nrf-softdevice/src/lib.rs
+++ b/nrf-softdevice/src/lib.rs
@@ -122,20 +122,6 @@ compile_error!("The selected softdevice does not support ble-peripheral.");
 ))]
 compile_error!("The selected softdevice does not support ble-l2cap.");
 
-#[cfg(feature = "nrf52805")]
-use nrf52805_pac as pac;
-#[cfg(feature = "nrf52810")]
-use nrf52810_pac as pac;
-#[cfg(feature = "nrf52811")]
-use nrf52811_pac as pac;
-#[cfg(feature = "nrf52820")]
-use nrf52820_pac as pac;
-#[cfg(feature = "nrf52832")]
-use nrf52832_pac as pac;
-#[cfg(feature = "nrf52833")]
-use nrf52833_pac as pac;
-#[cfg(feature = "nrf52840")]
-use nrf52840_pac as pac;
 #[cfg(feature = "s112")]
 pub use nrf_softdevice_s112 as raw;
 #[cfg(feature = "s113")]
@@ -169,3 +155,27 @@ pub use temperature::temperature_celsius;
 mod random;
 pub use nrf_softdevice_macro::*;
 pub use random::random_bytes;
+
+// Numbers of interrupts we care about are identical in all nRF52xxx.
+// We copypaste the enum here to avoid depending on the PAC, which avoids version conflicts.
+#[allow(non_camel_case_types, dead_code)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum Interrupt {
+    POWER_CLOCK = 0,
+    RADIO = 1,
+    TIMER0 = 8,
+    RTC0 = 11,
+    TEMP = 12,
+    RNG = 13,
+    ECB = 14,
+    CCM_AAR = 15,
+    SWI2_EGU2 = 22,
+    SWI5_EGU5 = 25,
+}
+
+unsafe impl cortex_m::interrupt::InterruptNumber for Interrupt {
+    #[inline]
+    fn number(self) -> u16 {
+        self as u16
+    }
+}

--- a/nrf-softdevice/src/softdevice.rs
+++ b/nrf-softdevice/src/softdevice.rs
@@ -3,7 +3,9 @@ use core::mem::MaybeUninit;
 use core::ptr;
 use core::sync::atomic::{AtomicBool, Ordering};
 
-use crate::{pac, raw, RawError, SocEvent};
+use cortex_m::peripheral::NVIC;
+
+use crate::{raw, Interrupt, RawError, SocEvent};
 
 unsafe extern "C" fn fault_handler(id: u32, pc: u32, info: u32) {
     match (id, info) {
@@ -70,7 +72,7 @@ fn get_app_ram_base() -> u32 {
         static mut __sdata: u32;
     }
 
-    unsafe { ptr::addr_of!(__sdata) as u32 }
+    ptr::addr_of!(__sdata) as u32
 }
 
 fn cfg_set(id: u32, cfg: &raw::ble_cfg_t) {
@@ -259,10 +261,7 @@ impl Softdevice {
         }
 
         unsafe {
-            #[cfg(any(feature = "nrf52805", feature = "nrf52810", feature = "nrf52811"))]
-            pac::NVIC::unmask(pac::interrupt::SWI2);
-            #[cfg(not(any(feature = "nrf52805", feature = "nrf52810", feature = "nrf52811")))]
-            pac::NVIC::unmask(pac::interrupt::SWI2_EGU2);
+            NVIC::unmask(Interrupt::SWI2_EGU2);
         }
 
         #[cfg(feature = "ble-gatt")]


### PR DESCRIPTION
https://github.com/embassy-rs/embassy/pull/3498 changed the PAC in use, so we have to update to be compatible.
Since we're only using the PAC for interrupt numbers, and they're equal for all nrf52, we might as well hardcode them
to avoid headaches.
