### PR TITLE
Support larger discovery characterisrics maximum buffer size

### DIFF
--- a/nrf-softdevice/Cargo.toml
+++ b/nrf-softdevice/Cargo.toml
@@ -50,6 +50,11 @@ ble-l2cap-credit-workaround = []
 evt-max-size-256 = []
 evt-max-size-512 = []
 
+# Support more discovery characteristics in GATT clients,
+# may be needed with higher ATT_MTU and peripherals with 
+# many service characteristics
+discovery-chars-12 = []
+
 [dependencies]
 defmt = { version = "0.3", optional = true }
 log = { version = "0.4.11", optional = true }

--- a/nrf-softdevice/src/ble/gatt_client.rs
+++ b/nrf-softdevice/src/ble/gatt_client.rs
@@ -106,7 +106,7 @@ impl From<RawError> for DiscoverError {
     }
 }
 
-const DISC_CHARS_MAX: usize = 6;
+const DISC_CHARS_MAX: usize = 12;
 const DISC_DESCS_MAX: usize = 6;
 
 pub(crate) async fn discover_service(conn: &Connection, uuid: Uuid) -> Result<raw::ble_gattc_service_t, DiscoverError> {

--- a/nrf-softdevice/src/ble/gatt_client.rs
+++ b/nrf-softdevice/src/ble/gatt_client.rs
@@ -106,7 +106,11 @@ impl From<RawError> for DiscoverError {
     }
 }
 
+#[cfg(not(feature = "discovery-chars-12"))]
+const DISC_CHARS_MAX: usize = 6;
+#[cfg(feature = "discovery-chars-12")]
 const DISC_CHARS_MAX: usize = 12;
+
 const DISC_DESCS_MAX: usize = 6;
 
 pub(crate) async fn discover_service(conn: &Connection, uuid: Uuid) -> Result<raw::ble_gattc_service_t, DiscoverError> {


### PR DESCRIPTION
Hi,

I just hit the panic here:

https://github.com/embassy-rs/nrf-softdevice/blob/master/nrf-softdevice/src/ble/gatt_client.rs#L179

And I can't see any way to increase the maximum number of characteristics when discovering services as it's hard-coded in `const DISC_CHARS_MAX`.

The problem does not exist when I have an `att_mtu` of `23` but when i increase the `att_mtu` to `247` which i need for more throughput reading some of the GATT characteristics then the problem appears.

In my case the packet contained 11 characteristics with an `att_mtu` of 247 so I have bumped it to 12 behind the `discovery-chars-12` feature flag (taking inspiration from the `evt-max-size-256` feature flag - which I also need).

I am tempted to do the same for `DISC_DESCS_MAX` but perhaps that's my OCD with consistency and symmetry so perhaps you can advise if you would prefer this or not?